### PR TITLE
Improve build_cmd tests

### DIFF
--- a/tests/test_tracks.py
+++ b/tests/test_tracks.py
@@ -3,13 +3,83 @@
 from core.tracks import build_cmd, Track
 from pathlib import Path
 
+
 def test_build_cmd_flags():
     src = Path("in.mkv")
     dst = Path("out.mkv")
     tracks = [
-        Track(idx=0, tid=1, type="audio", codec="aac", language="eng", forced=False, name="English", default_audio=True),
-        Track(idx=1, tid=2, type="subtitles", codec="srt", language="eng", forced=True, name="English CC", default_subtitle=True)
+        Track(
+            idx=0,
+            tid=1,
+            type="audio",
+            codec="aac",
+            language="eng",
+            forced=False,
+            name="English",
+            default_audio=True,
+        ),
+        Track(
+            idx=1,
+            tid=2,
+            type="subtitles",
+            codec="srt",
+            language="eng",
+            forced=True,
+            name="English CC",
+            default_subtitle=True,
+        ),
     ]
     cmd = build_cmd(src, dst, tracks, wipe_forced=True, wipe_all=False)
-    assert "--default-track" in cmd
-    assert "--forced-track" in cmd
+    assert cmd == [
+        "mkvmerge",
+        "--forced-track",
+        "2:no",
+        "--default-track",
+        "1:yes",
+        "--default-track",
+        "2:yes",
+        "-o",
+        str(dst),
+        str(src),
+    ]
+
+
+def test_build_cmd_wipe_all():
+    src = Path("in.mkv")
+    dst = Path("out.mkv")
+    tracks = [
+        Track(
+            idx=0,
+            tid=1,
+            type="audio",
+            codec="aac",
+            language="eng",
+            forced=False,
+            name="English",
+            default_audio=True,
+        ),
+        Track(
+            idx=1,
+            tid=2,
+            type="subtitles",
+            codec="srt",
+            language="eng",
+            forced=True,
+            name="English CC",
+            default_subtitle=True,
+        ),
+    ]
+    cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=True)
+    assert cmd == [
+        "mkvmerge",
+        "--no-subtitles",
+        "--forced-track",
+        "2:yes",
+        "--default-track",
+        "1:yes",
+        "--default-track",
+        "2:yes",
+        "-o",
+        str(dst),
+        str(src),
+    ]


### PR DESCRIPTION
## Summary
- check exact command list when building mkvmerge command
- add test case for wiping subtitle tracks

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684010ab21c88323b8a564d6b8280bff