### PR TITLE
Update comment on output_dir handling

### DIFF
--- a/gui/processing.py
+++ b/gui/processing.py
@@ -29,7 +29,7 @@ def process_files(jobs, max_workers, query_tracks, build_cmd, run_command, outpu
                 t.forced = False
                 t.default_audio = False
                 t.default_subtitle = False
-        # Fix: handle absolute or relative output_dir robustly
+        # Handle absolute or relative output_dir robustly
         output_dir_path = Path(output_dir)
         dst_dir = output_dir_path if output_dir_path.is_absolute() else (src.parent / output_dir_path)
         dst_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- clarify comment in GUI processing helper about output_dir behavior

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684010ab3df48323a772d674b4940247