### PR TITLE
Fix table selection crash

### DIFF
--- a/gui/models.py
+++ b/gui/models.py
@@ -82,3 +82,14 @@ class TrackTableModel(QAbstractTableModel):
 
     def get_tracks(self):
         return self.tracks
+
+    def track_at_row(self, row):
+        if isinstance(self.tracks, dict):
+            keys = sorted(self.tracks.keys())
+            if 0 <= row < len(keys):
+                return self.tracks[keys[row]]
+            raise KeyError(row)
+        else:
+            if 0 <= row < len(self.tracks):
+                return self.tracks[row]
+            raise IndexError(row)

--- a/gui/table_logic.py
+++ b/gui/table_logic.py
@@ -7,7 +7,7 @@ class TableLogic:
 
     def _on_table_clicked(self, index):
         if index.column() == 0:
-            t = self.track_table.model.tracks[index.row()]
+            t = self.track_table.model.track_at_row(index.row())
             t.removed = not t.removed
             self.track_table.model.dataChanged.emit(index, index, [Qt.CheckStateRole])
         self._on_selection_change(self.track_table.currentIndex(), None)
@@ -20,7 +20,7 @@ class TableLogic:
             btn.setEnabled(False)
         if not current.isValid():
             return
-        t = self.track_table.model.tracks[current.row()]
+        t = self.track_table.model.track_at_row(current.row())
         if t.removed:
             self.action_bar.btn_wipe_all.setEnabled(t.type == "subtitles")
             return


### PR DESCRIPTION
## Summary
- handle track lookup by row via `track_at_row`
- use this new helper in table logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401e357c1c8323b4ebe2a3bd5c5abf