### PR TITLE
Add optional FFmpeg backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ MKV Cleaner is an easy-to-use GUI for tidying Matroska (`.mkv`) files. You can q
 
 - [Python 3.10 or later](https://www.python.org/downloads/)
 - [PySide6](https://pypi.org/project/PySide6/)
-- [MKVToolNix](https://mkvtoolnix.download/) (`mkvmerge` and `mkvextract` must be in your `PATH`)
+- [MKVToolNix](https://mkvtoolnix.download/) (`mkvmerge` and `mkvextract` must be in your `PATH`) *(optional if using FFmpeg)*
+- [FFmpeg](https://ffmpeg.org/) (`ffmpeg` and `ffprobe` must be in your `PATH` if selected)
 
 After installing Python, open a command prompt and run `pip install pyside6` to install the GUI framework.
 
@@ -30,7 +31,7 @@ After installing Python, open a command prompt and run `pip install pyside6` to 
    - wipe all subtitles if desired
 5. Use **Process Group** or **Process All** to create cleaned files in the output directory (by default `cleaned/`).
 
-Paths to `mkvmerge`/`mkvextract`, the output directory and other options can be configured via the Preferences dialog (⚙️ icon).
+Paths to the command line tools, the output directory and the preferred backend (MKVToolNix or FFmpeg) can be configured via the Preferences dialog (⚙️ icon).
 
 ## Testing
 

--- a/core/config.py
+++ b/core/config.py
@@ -7,8 +7,11 @@ from pathlib import Path
 from typing import Any, Dict
 
 DEFAULTS: Dict[str, Any] = {
+    "backend": "mkvtoolnix",  # or "ffmpeg"
     "mkvmerge_cmd": "mkvmerge",
     "mkvextract_cmd": "mkvextract",
+    "ffmpeg_cmd": "ffmpeg",
+    "ffprobe_cmd": "ffprobe",
     "output_dir": "cleaned",
     "max_workers": 4,
 }

--- a/gui/actions_logic.py
+++ b/gui/actions_logic.py
@@ -95,7 +95,8 @@ class ActionsLogic:
             t.language,
             t.name,
             run_command,
-            DEFAULTS["mkvextract_cmd"],
+            DEFAULTS["ffmpeg_cmd"] if DEFAULTS.get("backend") == "ffmpeg" else DEFAULTS["mkvextract_cmd"],
+            DEFAULTS.get("backend", "mkvtoolnix"),
             parent=self,
         )
         self._preview_win.show()

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -2,7 +2,7 @@
 
 from PySide6.QtWidgets import (
     QDialog, QFormLayout, QLineEdit, QCheckBox, QFileDialog,
-    QDialogButtonBox, QPushButton, QWidget, QHBoxLayout
+    QDialogButtonBox, QPushButton, QWidget, QHBoxLayout, QComboBox
 )
 from PySide6.QtCore import QSettings
 
@@ -13,6 +13,11 @@ class PreferencesDialog(QDialog):
         self.settings = QSettings("MKVToolsCorp", "MKVCleaner")
 
         layout = QFormLayout(self)
+
+        self.backend = QComboBox(self)
+        self.backend.addItems(["mkvtoolnix", "ffmpeg"])
+        self.backend.setCurrentText(self.settings.value("backend", "mkvtoolnix"))
+        layout.addRow("Backend:", self.backend)
 
         self.merge_path = QLineEdit(self)
         self.merge_path.setText(self.settings.value("mkvmerge_cmd", "mkvmerge"))
@@ -25,6 +30,18 @@ class PreferencesDialog(QDialog):
         btn_x = QPushButton("…", self)
         btn_x.clicked.connect(lambda: self._pick_file(self.extract_path))
         layout.addRow("mkvextract command:", self._with_button(self.extract_path, btn_x))
+
+        self.ffmpeg_path = QLineEdit(self)
+        self.ffmpeg_path.setText(self.settings.value("ffmpeg_cmd", "ffmpeg"))
+        btn_fm = QPushButton("…", self)
+        btn_fm.clicked.connect(lambda: self._pick_file(self.ffmpeg_path))
+        layout.addRow("ffmpeg command:", self._with_button(self.ffmpeg_path, btn_fm))
+
+        self.ffprobe_path = QLineEdit(self)
+        self.ffprobe_path.setText(self.settings.value("ffprobe_cmd", "ffprobe"))
+        btn_fp = QPushButton("…", self)
+        btn_fp.clicked.connect(lambda: self._pick_file(self.ffprobe_path))
+        layout.addRow("ffprobe command:", self._with_button(self.ffprobe_path, btn_fp))
 
         self.output_dir = QLineEdit(self)
         self.output_dir.setText(self.settings.value("output_dir", "cleaned"))
@@ -53,8 +70,11 @@ class PreferencesDialog(QDialog):
             line_edit.setText(path)
 
     def accept(self) -> None:
+        self.settings.setValue("backend", self.backend.currentText())
         self.settings.setValue("mkvmerge_cmd", self.merge_path.text())
         self.settings.setValue("mkvextract_cmd", self.extract_path.text())
+        self.settings.setValue("ffmpeg_cmd", self.ffmpeg_path.text())
+        self.settings.setValue("ffprobe_cmd", self.ffprobe_path.text())
         self.settings.setValue("output_dir", self.output_dir.text())
         self.settings.setValue("wipe_all_default", self.wipe_all_def.isChecked())
         super().accept()

--- a/gui/settings_logic.py
+++ b/gui/settings_logic.py
@@ -17,8 +17,11 @@ class SettingsLogic:
 
     def _load_preferences(self):
         prefs = load_config()
+        prefs["backend"]        = self.settings.value("backend", prefs["backend"])
         prefs["mkvmerge_cmd"]   = self.settings.value("mkvmerge_cmd", prefs["mkvmerge_cmd"])
         prefs["mkvextract_cmd"] = self.settings.value("mkvextract_cmd", prefs["mkvextract_cmd"])
+        prefs["ffmpeg_cmd"]     = self.settings.value("ffmpeg_cmd", prefs["ffmpeg_cmd"])
+        prefs["ffprobe_cmd"]    = self.settings.value("ffprobe_cmd", prefs["ffprobe_cmd"])
         prefs["output_dir"]     = self.settings.value("output_dir", prefs["output_dir"])
         DEFAULTS.update(prefs)
         self.last_input_dir   = self.settings.value("last_input_dir", "", type=str)

--- a/tests/test_tracks.py
+++ b/tests/test_tracks.py
@@ -7,6 +7,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core.tracks import build_cmd, Track  # noqa: E402
+from core.config import DEFAULTS
 
 
 def test_build_cmd_flags():
@@ -34,6 +35,7 @@ def test_build_cmd_flags():
             default_subtitle=True,
         ),
     ]
+    DEFAULTS["backend"] = "mkvtoolnix"
     cmd = build_cmd(src, dst, tracks, wipe_forced=True, wipe_all=False)
     assert cmd == [
         "mkvmerge",
@@ -46,6 +48,23 @@ def test_build_cmd_flags():
         "-o",
         str(dst),
         str(src),
+    ]
+
+    DEFAULTS["backend"] = "ffmpeg"
+    cmd = build_cmd(src, dst, tracks, wipe_forced=True, wipe_all=False)
+    assert cmd == [
+        "ffmpeg",
+        "-i",
+        str(src),
+        "-map",
+        "0",
+        "-disposition:a:0",
+        "default",
+        "-disposition:s:0",
+        "default",
+        "-c",
+        "copy",
+        str(dst),
     ]
 
 
@@ -74,6 +93,7 @@ def test_build_cmd_wipe_all():
             default_subtitle=True,
         ),
     ]
+    DEFAULTS["backend"] = "mkvtoolnix"
     cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=True)
     assert cmd == [
         "mkvmerge",
@@ -87,4 +107,21 @@ def test_build_cmd_wipe_all():
         "-o",
         str(dst),
         str(src),
+    ]
+
+    DEFAULTS["backend"] = "ffmpeg"
+    cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=True)
+    assert cmd == [
+        "ffmpeg",
+        "-i",
+        str(src),
+        "-map",
+        "0",
+        "-map",
+        "-0:2",
+        "-disposition:a:0",
+        "default",
+        "-c",
+        "copy",
+        str(dst),
     ]


### PR DESCRIPTION
## Summary
- add `backend` setting with FFmpeg support
- implement FFmpeg versions of track querying, command building, and subtitle extraction
- extend preferences UI with backend and FFmpeg options
- update settings logic
- adjust actions logic for new preview arguments
- document FFmpeg as an alternative in README
- expand tests to cover both backends

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840497abe0883238a7fe327e8e96cf9