### PR TITLE
Fix ffmpeg disposition join

### DIFF
--- a/core/tracks.py
+++ b/core/tracks.py
@@ -181,7 +181,7 @@ def _build_cmd_ffmpeg(
             disp_flags.append("forced")
         if t.default_subtitle:
             disp_flags.append("default")
-        disp = ",".join(disp_flags) if disp_flags else "0"
+        disp = "+".join(disp_flags) if disp_flags else "0"
         cmd += [f"-disposition:s:{i}", disp]
 
     cmd += ["-c", "copy", str(destination)]

--- a/tests/test_tracks.py
+++ b/tests/test_tracks.py
@@ -125,3 +125,61 @@ def test_build_cmd_wipe_all():
         "copy",
         str(dst),
     ]
+
+
+def test_build_cmd_forced_default_ffmpeg():
+    src = Path("in.mkv")
+    dst = Path("out.mkv")
+    tracks = [
+        Track(
+            idx=0,
+            tid=1,
+            type="audio",
+            codec="aac",
+            language="eng",
+            forced=False,
+            name="English",
+            default_audio=True,
+        ),
+        Track(
+            idx=1,
+            tid=2,
+            type="subtitles",
+            codec="srt",
+            language="eng",
+            forced=True,
+            name="English CC",
+            default_subtitle=True,
+        ),
+    ]
+    DEFAULTS["backend"] = "mkvtoolnix"
+    cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=False)
+    assert cmd == [
+        "mkvmerge",
+        "--forced-track",
+        "2:yes",
+        "--default-track",
+        "1:yes",
+        "--default-track",
+        "2:yes",
+        "-o",
+        str(dst),
+        str(src),
+    ]
+
+    DEFAULTS["backend"] = "ffmpeg"
+    cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=False)
+    assert cmd == [
+        "ffmpeg",
+        "-i",
+        str(src),
+        "-map",
+        "0",
+        "-disposition:a:0",
+        "default",
+        "-disposition:s:0",
+        "forced+default",
+        "-c",
+        "copy",
+        str(dst),
+    ]


### PR DESCRIPTION
## Summary
- fix ffmpeg command generation to join disposition flags with `+`
- add regression tests covering forced+default flags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404d7828888323a069d1460d4adbdf