### PR TITLE
Move status bar between track list and action bar

### DIFF
--- a/gui/actions_logic.py
+++ b/gui/actions_logic.py
@@ -37,8 +37,8 @@ class ActionsLogic:
                 tr.default_audio = False
         t.default_audio = True
         self.track_table.model.update_tracks(self.track_table.model.tracks)
-        if hasattr(self, "statusBar"):
-            self.statusBar().showMessage("Default audio set", 2000)
+        if hasattr(self, "status_bar"):
+            self.status_bar.showMessage("Default audio set", 2000)
 
     def set_default_subtitle(self):
         row = self._current_idx()
@@ -52,8 +52,8 @@ class ActionsLogic:
                 tr.default_subtitle = False
         t.default_subtitle = True
         self.track_table.model.update_tracks(self.track_table.model.tracks)
-        if hasattr(self, "statusBar"):
-            self.statusBar().showMessage("Default subtitle set", 2000)
+        if hasattr(self, "status_bar"):
+            self.status_bar.showMessage("Default subtitle set", 2000)
 
     def set_forced_subtitle(self):
         row = self._current_idx()
@@ -64,8 +64,8 @@ class ActionsLogic:
             return
         t.forced = not t.forced
         self.track_table.model.update_tracks(self.track_table.model.tracks)
-        if hasattr(self, "statusBar"):
-            self.statusBar().showMessage("Forced flag toggled", 2000)
+        if hasattr(self, "status_bar"):
+            self.status_bar.showMessage("Forced flag toggled", 2000)
 
     def wipe_all_subs(self):
         changed = False
@@ -75,8 +75,8 @@ class ActionsLogic:
                 changed = True
         if changed:
             self.track_table.model.update_tracks(self.track_table.model.tracks)
-            if hasattr(self, "statusBar"):
-                self.statusBar().showMessage("All subtitles marked for removal", 2000)
+            if hasattr(self, "status_bar"):
+                self.status_bar.showMessage("All subtitles marked for removal", 2000)
 
     def preview_subtitle(self):
         row = self._current_idx()

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,4 +1,10 @@
-from PySide6.QtWidgets import QMainWindow, QVBoxLayout, QWidget, QFileDialog
+from PySide6.QtWidgets import (
+    QMainWindow,
+    QVBoxLayout,
+    QWidget,
+    QFileDialog,
+    QStatusBar,
+)
 from PySide6.QtCore import QSettings
 import os
 
@@ -24,12 +30,15 @@ class MainWindow(QMainWindow, SettingsLogic, GroupLogic, TableLogic, ActionsLogi
         self.group_bar = GroupBar(self)
         self.action_bar = ActionBar(self)
         self.track_table = TrackTable(self)
+        self.status_bar = QStatusBar(self)
+        self.status_bar.setSizeGripEnabled(False)
 
         main_vbox = QVBoxLayout()
         main_vbox.setContentsMargins(0, 0, 0, 0)
         main_vbox.setSpacing(0)
         main_vbox.addWidget(self.group_bar)
         main_vbox.addWidget(self.track_table)
+        main_vbox.addWidget(self.status_bar)
         main_vbox.addWidget(self.action_bar)
 
         container = QWidget()


### PR DESCRIPTION
## Summary
- add a dedicated `QStatusBar` widget to the main layout
- show messages using the new status bar

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68404f1f614483238a781234ee6a4d18