### PR TITLE
Add fixture to reset DEFAULTS in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import copy
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from core.config import DEFAULTS
+
+
+@pytest.fixture
+def defaults():
+    backup = copy.deepcopy(DEFAULTS)
+    yield DEFAULTS
+    DEFAULTS.clear()
+    DEFAULTS.update(backup)

--- a/tests/test_tracks.py
+++ b/tests/test_tracks.py
@@ -7,10 +7,9 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core.tracks import build_cmd, Track  # noqa: E402
-from core.config import DEFAULTS
 
 
-def test_build_cmd_flags():
+def test_build_cmd_flags(defaults):
     src = Path("in.mkv")
     dst = Path("out.mkv")
     tracks = [
@@ -35,7 +34,7 @@ def test_build_cmd_flags():
             default_subtitle=True,
         ),
     ]
-    DEFAULTS["backend"] = "mkvtoolnix"
+    defaults["backend"] = "mkvtoolnix"
     cmd = build_cmd(src, dst, tracks, wipe_forced=True, wipe_all=False)
     assert cmd == [
         "mkvmerge",
@@ -50,7 +49,7 @@ def test_build_cmd_flags():
         str(src),
     ]
 
-    DEFAULTS["backend"] = "ffmpeg"
+    defaults["backend"] = "ffmpeg"
     cmd = build_cmd(src, dst, tracks, wipe_forced=True, wipe_all=False)
     assert cmd == [
         "ffmpeg",
@@ -68,7 +67,7 @@ def test_build_cmd_flags():
     ]
 
 
-def test_build_cmd_wipe_all():
+def test_build_cmd_wipe_all(defaults):
     src = Path("in.mkv")
     dst = Path("out.mkv")
     tracks = [
@@ -93,7 +92,7 @@ def test_build_cmd_wipe_all():
             default_subtitle=True,
         ),
     ]
-    DEFAULTS["backend"] = "mkvtoolnix"
+    defaults["backend"] = "mkvtoolnix"
     cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=True)
     assert cmd == [
         "mkvmerge",
@@ -109,7 +108,7 @@ def test_build_cmd_wipe_all():
         str(src),
     ]
 
-    DEFAULTS["backend"] = "ffmpeg"
+    defaults["backend"] = "ffmpeg"
     cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=True)
     assert cmd == [
         "ffmpeg",
@@ -127,7 +126,7 @@ def test_build_cmd_wipe_all():
     ]
 
 
-def test_build_cmd_forced_default_ffmpeg():
+def test_build_cmd_forced_default_ffmpeg(defaults):
     src = Path("in.mkv")
     dst = Path("out.mkv")
     tracks = [
@@ -152,7 +151,7 @@ def test_build_cmd_forced_default_ffmpeg():
             default_subtitle=True,
         ),
     ]
-    DEFAULTS["backend"] = "mkvtoolnix"
+    defaults["backend"] = "mkvtoolnix"
     cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=False)
     assert cmd == [
         "mkvmerge",
@@ -167,7 +166,7 @@ def test_build_cmd_forced_default_ffmpeg():
         str(src),
     ]
 
-    DEFAULTS["backend"] = "ffmpeg"
+    defaults["backend"] = "ffmpeg"
     cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=False)
     assert cmd == [
         "ffmpeg",


### PR DESCRIPTION
## Summary
- add `defaults` fixture backing up `DEFAULTS`
- use the fixture in `tests/test_tracks.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c9fff8848323889ecc76422af179