### PR TITLE
Improve processing cancellation

### DIFF
--- a/gui/processing.py
+++ b/gui/processing.py
@@ -1,5 +1,8 @@
 from PySide6.QtCore import QMetaObject, Q_ARG, Qt
 from PySide6.QtWidgets import QProgressDialog, QMessageBox
+import logging
+
+logger = logging.getLogger(__name__)
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -35,7 +38,7 @@ def process_files(jobs, max_workers, query_tracks, build_cmd, run_command, outpu
         dst_dir.mkdir(exist_ok=True)
         dst = dst_dir / src.name
         cmd = build_cmd(src, dst, real_tracks, wipe_forced=False, wipe_all=wipe_all_flag)
-        print("Running:", " ".join(map(str, cmd)))
+        logger.info("Running: %s", " ".join(map(str, cmd)))
         try:
             run_command(cmd)
         except Exception as e:
@@ -51,6 +54,7 @@ def process_files(jobs, max_workers, query_tracks, build_cmd, run_command, outpu
         for i, fut in enumerate(as_completed(futures), 1):
             update_progress_in_main_thread(i)
             if dlg.wasCanceled():
+                executor.shutdown(cancel_futures=True)
                 break
 
     dlg.close()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,0 +1,119 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import types
+sys.modules['PySide6'] = types.ModuleType('PySide6')
+qtcore = types.ModuleType('PySide6.QtCore')
+qtcore.QMetaObject = type('QMetaObject', (), {'invokeMethod': lambda *a, **k: None})
+qtcore.Q_ARG = lambda typ, val: val
+qtcore.Qt = type('Qt', (), {'WindowModal': 0, 'QueuedConnection': 0})
+sys.modules['PySide6.QtCore'] = qtcore
+
+qtwidgets = types.ModuleType('PySide6.QtWidgets')
+qtwidgets.QProgressDialog = object
+qtwidgets.QMessageBox = type('QMessageBox', (), {
+    'warning': staticmethod(lambda *a, **k: None),
+    'information': staticmethod(lambda *a, **k: None),
+})
+sys.modules['PySide6.QtWidgets'] = qtwidgets
+
+import gui.processing as processing  # noqa: E402
+
+
+class DummyDialog:
+    def __init__(self):
+        self._val = 0
+        self._canceled = False
+
+    def setWindowModality(self, *a):
+        pass
+
+    def setMinimumDuration(self, *a):
+        pass
+
+    def setValue(self, val):
+        self._val = val
+        if val >= 1:
+            self._canceled = True
+
+    def wasCanceled(self):
+        return self._canceled
+
+    def close(self):
+        pass
+
+
+class DummyExecutor:
+    def __init__(self, *a, **kw):
+        self.shutdown_called = {}
+        self.tasks = []
+
+    def submit(self, fn, *args, **kwargs):
+        fut = DummyFuture(fn, *args, **kwargs)
+        self.tasks.append(fut)
+        return fut
+
+    def shutdown(self, wait=True, cancel_futures=False):
+        self.shutdown_called = {"wait": wait, "cancel_futures": cancel_futures}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if not self.shutdown_called:
+            self.shutdown()
+
+
+class DummyFuture:
+    def __init__(self, fn, *args, **kwargs):
+        self.fn = fn
+        self.args = args
+        self.kw = kwargs
+        self._result = None
+
+    def run(self):
+        self._result = self.fn(*self.args, **self.kw)
+
+    def result(self):
+        if self._result is None:
+            self.run()
+        return self._result
+
+
+def dummy_as_completed(futures):
+    for f in futures:
+        f.run()
+        yield f
+
+
+def test_cancel_shutdown(monkeypatch):
+    jobs = [(Path("a"), []), (Path("b"), [])]
+    commands = []
+
+    def query_tracks(src):
+        return []
+
+    def build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=False):
+        return ["cmd", str(src), str(dst)]
+
+    def run_command(cmd):
+        commands.append(cmd)
+
+    dlg = DummyDialog()
+
+    monkeypatch.setattr(processing, "QProgressDialog", lambda *a, **kw: dlg)
+    monkeypatch.setattr(processing, "QMetaObject", type("_", (), {"invokeMethod": lambda *a: a[0].setValue(a[3])}))
+    monkeypatch.setattr(processing, "Q_ARG", lambda *a: a[1])
+    exec_instance = DummyExecutor()
+    monkeypatch.setattr(processing, "ThreadPoolExecutor", lambda *a, **kw: exec_instance)
+    monkeypatch.setattr(processing, "as_completed", dummy_as_completed)
+
+    processing.process_files(jobs, max_workers=2, query_tracks=query_tracks,
+                             build_cmd=build_cmd, run_command=run_command,
+                             output_dir="out", wipe_all_flag=False)
+
+    assert len(commands) == 1
+    assert exec_instance.shutdown_called.get("cancel_futures") is True


### PR DESCRIPTION
## Summary
- log processing actions instead of printing
- cancel futures on user abort
- test cancellation shutdown behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c9fed5bc8323a5f1b07fefcf0e11