### PR TITLE
Add backend switch dropdown

### DIFF
--- a/gui/group_logic.py
+++ b/gui/group_logic.py
@@ -48,3 +48,18 @@ class GroupLogic:
         if self.group_bar.group_buttons:
             self.group_bar.set_checked(0)
             self._on_group_change_idx(0)
+
+    def _reload_all_groups(self):
+        """Re-import already loaded files using the current backend."""
+        all_paths = []
+        for files in self.file_groups.values():
+            all_paths.extend(files)
+
+        self.groups.clear()
+        self.file_groups.clear()
+        self.current_sig = None
+        self.group_bar.clear()
+        self.track_table.model.update_tracks([])
+
+        if all_paths:
+            self.add_files_to_groups(all_paths)

--- a/gui/settings_logic.py
+++ b/gui/settings_logic.py
@@ -14,6 +14,9 @@ class SettingsLogic:
             self.action_bar.btn_wipe_all.setChecked(self.wipe_all_default)
         if hasattr(self, "menu_preferences"):
             self.menu_preferences.triggered.connect(self._open_preferences)
+        if hasattr(self, "group_bar") and hasattr(self.group_bar, "backend_combo"):
+            self.group_bar.set_backend(DEFAULTS.get("backend", "mkvtoolnix"))
+            self.group_bar.backendChanged.connect(self._change_backend)
 
     def _load_preferences(self):
         prefs = load_config()
@@ -26,6 +29,8 @@ class SettingsLogic:
         DEFAULTS.update(prefs)
         self.last_input_dir   = self.settings.value("last_input_dir", "", type=str)
         self.wipe_all_default = self.settings.value("wipe_all_default", False, type=bool)
+        if hasattr(self, "group_bar") and hasattr(self.group_bar, "set_backend"):
+            self.group_bar.set_backend(DEFAULTS.get("backend", "mkvtoolnix"))
 
     def _open_preferences(self):
         dlg = PreferencesDialog(self)
@@ -33,6 +38,12 @@ class SettingsLogic:
             self._load_preferences()
             if hasattr(self.action_bar, "btn_wipe_all"):
                 self.action_bar.btn_wipe_all.setChecked(self.wipe_all_default)
+
+    def _change_backend(self, backend: str):
+        DEFAULTS["backend"] = backend
+        self.settings.setValue("backend", backend)
+        if hasattr(self, "_reload_all_groups"):
+            self._reload_all_groups()
 
     def closeEvent(self, event):
         if hasattr(self, "track_table") and hasattr(self.track_table, "horizontalHeader"):

--- a/gui/widgets/group_bar.py
+++ b/gui/widgets/group_bar.py
@@ -5,12 +5,15 @@ from PySide6.QtWidgets import (
     QPushButton,
     QButtonGroup,
     QSizePolicy,
+    QComboBox,
 )
 from PySide6.QtCore import Qt, QSize, Signal
+from core.config import DEFAULTS
 
 
 class GroupBar(QWidget):
     preferencesClicked = Signal()
+    backendChanged = Signal(str)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -33,6 +36,14 @@ class GroupBar(QWidget):
         self.group_btns_anchor = self.layout.count()
         self.stretch = self.layout.addStretch(1)
 
+        self.backend_combo = QComboBox(self)
+        self.backend_combo.addItems(["mkvtoolnix", "ffmpeg"])
+        self.backend_combo.setCurrentText(DEFAULTS.get("backend", "mkvtoolnix"))
+        self.backend_combo.setToolTip("Select backend")
+        self.backend_combo.currentTextChanged.connect(self.backendChanged.emit)
+        self.backend_combo.setFixedHeight(32)
+        self.layout.addWidget(self.backend_combo, alignment=Qt.AlignRight)
+
         self.btn_prefs = QPushButton("⚙️")
         self.btn_prefs.setMinimumSize(QSize(44, 42))
         self.btn_prefs.setMaximumSize(QSize(44, 42))
@@ -48,6 +59,14 @@ class GroupBar(QWidget):
 
         self.setLayout(self.layout)
         self.setFixedHeight(54)
+
+    def set_backend(self, backend: str):
+        """Update dropdown to reflect the selected backend."""
+        if backend not in {"mkvtoolnix", "ffmpeg"}:
+            return
+        self.backend_combo.blockSignals(True)
+        self.backend_combo.setCurrentText(backend)
+        self.backend_combo.blockSignals(False)
 
     def add_group_button(self, sig, tooltip=None):
         btn = QPushButton(str(len(self.group_buttons) + 1))


### PR DESCRIPTION
## Summary
- allow changing backend from group bar
- reload file data when backend changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d0da09f08323aa4ca26570427a08