### PR TITLE
Add helpful tooltips to ActionBar

### DIFF
--- a/gui/widgets/action_bar.py
+++ b/gui/widgets/action_bar.py
@@ -12,15 +12,37 @@ class ActionBar(QWidget):
         layout.setSpacing(8)
 
         self.btn_open_files = QPushButton("📂 Open Files...")
+        self.btn_open_files.setToolTip("Choose one or more MKV videos.")
+
         self.btn_def_audio = QPushButton("🔊 Default Audio")
+        self.btn_def_audio.setToolTip(
+            "Set which audio track should play by default."
+        )
+
         self.btn_def_sub = QPushButton("💬 Default Subtitle")
+        self.btn_def_sub.setToolTip(
+            "Set which subtitle track is shown automatically."
+        )
+
         self.btn_forced = QPushButton("🏳️‍🌈 Set Forced")
+        self.btn_forced.setToolTip(
+            "Mark selected subtitles as forced so players show them."
+        )
+
         self.btn_wipe_all = QPushButton("🧹 Wipe All Subs")
+        self.btn_wipe_all.setToolTip("Remove every subtitle from these videos.")
         # Allow toggling so the state can be used when processing files
         self.btn_wipe_all.setCheckable(True)
         self.btn_preview = QPushButton("👁️ Preview Subtitle")
+        self.btn_preview.setToolTip("Quickly check the subtitles before processing.")
+
         self.btn_process_group = QPushButton("📦 Process Group")
+        self.btn_process_group.setToolTip(
+            "Apply cleaning to the current group only."
+        )
+
         self.btn_process_all = QPushButton("🚀 Process All")
+        self.btn_process_all.setToolTip("Clean all loaded groups of videos.")
 
         for btn in (
             self.btn_open_files,

--- a/gui/widgets/fast_tooltip_style.py
+++ b/gui/widgets/fast_tooltip_style.py
@@ -1,0 +1,10 @@
+from PySide6.QtWidgets import QProxyStyle, QStyle
+
+
+class FastToolTipStyle(QProxyStyle):
+    """Style proxy that reduces the delay before tooltips show."""
+
+    def styleHint(self, hint, option=None, widget=None, returnData=None):
+        if hint == QStyle.SH_ToolTip_WakeUpDelay:
+            return 100  # show tooltips quickly
+        return super().styleHint(hint, option, widget, returnData)

--- a/mkv_cleaner.py
+++ b/mkv_cleaner.py
@@ -6,6 +6,7 @@ console script or execute this module directly to launch the application.
 """
 
 from gui.main_window import MainWindow
+from gui.widgets.fast_tooltip_style import FastToolTipStyle
 from PySide6.QtWidgets import QApplication
 import sys
 import random
@@ -79,6 +80,8 @@ def set_dynamic_modern_style(app: QApplication) -> None:
 def main() -> None:
     """Create the application and show the main window."""
     app = QApplication(sys.argv)
+    # Show tooltips faster than the Qt default
+    app.setStyle(FastToolTipStyle(app.style()))
     set_dynamic_modern_style(app)
     win = MainWindow()
     win.show()


### PR DESCRIPTION
## Summary
- provide descriptive tooltips on ActionBar buttons
- reduce global tooltip wakeup delay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d22b3f3c8323bdfc9097dbcbc1ce