### PR TITLE
Add packaging workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,29 @@
+name: Package
+
+on:
+  schedule:
+    - cron: '0 */2 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: package
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install build dependencies
+        run: pip install build
+      - name: Build package
+        run: python -m build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: mkv-cleaner-dist
+          path: dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "mkv-cleaner"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = ["pyside6"]
 
-[tool.poetry.scripts]
+[project.scripts]
 mkv-cleaner = "mkv_cleaner:main"
+
+[tool.setuptools]
+py-modules = ["mkv_cleaner"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["core", "gui"]
+exclude = ["out"]


### PR DESCRIPTION
## Summary
- enable packaging via setuptools
- add scheduled GitHub workflow to build packages every two hours

## Testing
- `pytest -q`
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_6841d77a9d2483238dd93c40cf726bd2