### PR TITLE
Handle forced/default flags for all tracks

### DIFF
--- a/core/tracks.py
+++ b/core/tracks.py
@@ -131,21 +131,22 @@ def _build_cmd_mkvmerge(
         cmd += ["--subtitle-tracks", ",".join(kept_sub)]
 
     # Forced flags
-    if wipe_forced:
-        for t in tracks:
-            if t.type == "subtitles" and not t.removed:
+    for t in tracks:
+        if t.type == "subtitles" and not t.removed:
+            if wipe_forced:
                 cmd += ["--forced-track", f"{t.tid}:no"]
-    else:
-        for t in tracks:
-            if t.type == "subtitles" and t.forced and not t.removed:
-                cmd += ["--forced-track", f"{t.tid}:yes"]
+            else:
+                val = "yes" if t.forced else "no"
+                cmd += ["--forced-track", f"{t.tid}:{val}"]
 
     # Default flags
     for t in tracks:
-        if not t.removed and t.type == "audio" and t.default_audio:
-            cmd += ["--default-track", f"{t.tid}:yes"]
-        if not t.removed and t.type == "subtitles" and t.default_subtitle:
-            cmd += ["--default-track", f"{t.tid}:yes"]
+        if not t.removed and t.type in {"audio", "subtitles"}:
+            if t.type == "audio":
+                val = "yes" if t.default_audio else "no"
+            else:
+                val = "yes" if t.default_subtitle else "no"
+            cmd += ["--default-track", f"{t.tid}:{val}"]
 
     # Output and input file MUST come last
     cmd += ["-o", str(destination), str(source)]

--- a/tests/test_tracks.py
+++ b/tests/test_tracks.py
@@ -182,3 +182,70 @@ def test_build_cmd_forced_default_ffmpeg(defaults):
         "copy",
         str(dst),
     ]
+
+
+def test_build_cmd_full_flags(defaults):
+    src = Path("in.mkv")
+    dst = Path("out.mkv")
+    tracks = [
+        Track(
+            idx=0,
+            tid=1,
+            type="audio",
+            codec="aac",
+            language="eng",
+            forced=False,
+            name="English",
+            default_audio=False,
+        ),
+        Track(
+            idx=1,
+            tid=2,
+            type="audio",
+            codec="aac",
+            language="deu",
+            forced=False,
+            name="Deutsch",
+            default_audio=True,
+        ),
+        Track(
+            idx=2,
+            tid=3,
+            type="subtitles",
+            codec="srt",
+            language="eng",
+            forced=False,
+            name="English Subs",
+            default_subtitle=False,
+        ),
+        Track(
+            idx=3,
+            tid=4,
+            type="subtitles",
+            codec="srt",
+            language="spa",
+            forced=True,
+            name="Spanish",
+            default_subtitle=True,
+        ),
+    ]
+    defaults["backend"] = "mkvtoolnix"
+    cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=False)
+    assert cmd == [
+        "mkvmerge",
+        "--forced-track",
+        "3:no",
+        "--forced-track",
+        "4:yes",
+        "--default-track",
+        "1:no",
+        "--default-track",
+        "2:yes",
+        "--default-track",
+        "3:no",
+        "--default-track",
+        "4:yes",
+        "-o",
+        str(dst),
+        str(src),
+    ]


### PR DESCRIPTION
## Summary
- respect forced-track wipe when building mkvmerge command
- always specify forced/default flags for every track
- test behaviour for additional audio and subtitle tracks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e916e8348323a8dfe76fb526fa6b