### PR TITLE
Add tests for forced and default flags

### DIFF
--- a/core/tracks.py
+++ b/core/tracks.py
@@ -131,21 +131,21 @@ def _build_cmd_mkvmerge(
         cmd += ["--subtitle-tracks", ",".join(kept_sub)]
 
     # Forced flags
-    if wipe_forced:
-        for t in tracks:
-            if t.type == "subtitles" and not t.removed:
+    for t in tracks:
+        if t.type == "subtitles" and not t.removed:
+            if wipe_forced or not t.forced:
                 cmd += ["--forced-track", f"{t.tid}:no"]
-    else:
-        for t in tracks:
-            if t.type == "subtitles" and t.forced and not t.removed:
+            else:
                 cmd += ["--forced-track", f"{t.tid}:yes"]
 
     # Default flags
     for t in tracks:
-        if not t.removed and t.type == "audio" and t.default_audio:
-            cmd += ["--default-track", f"{t.tid}:yes"]
-        if not t.removed and t.type == "subtitles" and t.default_subtitle:
-            cmd += ["--default-track", f"{t.tid}:yes"]
+        if not t.removed and t.type == "audio":
+            flag = "yes" if t.default_audio else "no"
+            cmd += ["--default-track", f"{t.tid}:{flag}"]
+        if not t.removed and t.type == "subtitles":
+            flag = "yes" if t.default_subtitle else "no"
+            cmd += ["--default-track", f"{t.tid}:{flag}"]
 
     # Output and input file MUST come last
     cmd += ["-o", str(destination), str(source)]

--- a/tests/test_tracks.py
+++ b/tests/test_tracks.py
@@ -182,3 +182,74 @@ def test_build_cmd_forced_default_ffmpeg(defaults):
         "copy",
         str(dst),
     ]
+
+
+def test_mkvmerge_forced_false(defaults):
+    src = Path("in.mkv")
+    dst = Path("out.mkv")
+    tracks = [
+        Track(
+            idx=0,
+            tid=1,
+            type="subtitles",
+            codec="srt",
+            language="eng",
+            forced=False,
+            name="English",
+            default_subtitle=True,
+        ),
+    ]
+    defaults["backend"] = "mkvtoolnix"
+    cmd = build_cmd(src, dst, tracks, wipe_forced=True, wipe_all=False)
+    assert cmd == [
+        "mkvmerge",
+        "--no-audio",
+        "--forced-track",
+        "1:no",
+        "--default-track",
+        "1:yes",
+        "-o",
+        str(dst),
+        str(src),
+    ]
+
+
+def test_mkvmerge_default_no(defaults):
+    src = Path("in.mkv")
+    dst = Path("out.mkv")
+    tracks = [
+        Track(
+            idx=0,
+            tid=1,
+            type="audio",
+            codec="aac",
+            language="eng",
+            forced=False,
+            name="English",
+            default_audio=False,
+        ),
+        Track(
+            idx=1,
+            tid=2,
+            type="subtitles",
+            codec="srt",
+            language="eng",
+            forced=False,
+            name="English CC",
+            default_subtitle=False,
+        ),
+    ]
+    defaults["backend"] = "mkvtoolnix"
+    cmd = build_cmd(src, dst, tracks, wipe_forced=True, wipe_all=False)
+    assert cmd == [
+        "mkvmerge",
+        "--forced-track",
+        "2:no",
+        "--default-track",
+        "1:no",
+        "--default-track",
+        "2:no",
+        "-o",
+        str(dst),
+        str(src),
+    ]


### PR DESCRIPTION
## Summary
- extend tests for mkvmerge command building
- mark tracks as forced or not and verify flags
- ensure default track flags use yes/no

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e922d99c8323aa1afc858801da74