### PR TITLE
Switch packaging to manual workflow

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -1,13 +1,11 @@
 name: Package Windows
 
 on:
-  push:
-    branches: [main]
-  schedule:
-    - cron: '*/5 * * * *'
+  workflow_dispatch:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   build:
@@ -59,7 +57,7 @@ jobs:
 
       - name: Upload artifacts
         if: steps.changes.outputs.changed == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package
           path: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,13 +1,11 @@
 name: Package
 
 on:
-  push:
-    branches: [main]
-  schedule:
-    - cron: '*/5 * * * *'
+  workflow_dispatch:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   build:
@@ -55,7 +53,7 @@ jobs:
 
       - name: Upload artifacts
         if: steps.changes.outputs.changed == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package
           path: |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ their licenses are distributed alongside the bundle.
 
 ## Downloads
 
-A scheduled workflow checks every five minutes and uploads new bundles to the GitHub Releases section only when there have been changes. Download the archive for your platform and run the `mkv-cleaner` executable contained inside.
+New bundles are uploaded manually through a GitHub workflow whenever changes are ready. To build a new release, open the **Actions** tab on GitHub, select either **Package** or **Package Windows** and choose **Run workflow**. Download the archive for your platform from the Releases section and run the `mkv-cleaner` executable contained inside.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- trigger package workflows only via workflow_dispatch
- update README to mention manual build uploads
- fix packaging workflow permissions
- upgrade upload-artifact action to v4
- document how to run manual workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841edf3ad008323be1f54047799cf89