### PR TITLE
Fix windows release visibility

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           tag_name: nightly-${{ github.run_number }}
           name: "Nightly Build ${{ github.run_number }}"
-          prerelease: true
+          prerelease: false
           generate_release_notes: true
           files: |
             dist/*.whl


### PR DESCRIPTION
## Summary
- mark Windows package workflow as a normal release instead of a pre-release

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841f4f50e548323b011732951e668ed