### PR TITLE
Add tomli dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ When running from source you need to install the following tools yourself:
 
 - [Python 3.10 or later](https://www.python.org/downloads/)
 - [PySide6](https://pypi.org/project/PySide6/)
+- [tomli](https://pypi.org/project/tomli/) *(for Python < 3.11)*
 - [MKVToolNix](https://mkvtoolnix.download/) (`mkvmerge` and `mkvextract` on your `PATH`) *(optional if using FFmpeg)*
 - [FFmpeg](https://ffmpeg.org/) (`ffmpeg` and `ffprobe` on your `PATH` if selected)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ build-backend = "setuptools.build_meta"
 name = "mkv-cleaner"
 version = "0.1.0"
 requires-python = ">=3.10"
-dependencies = ["pyside6"]
+dependencies = [
+    "pyside6",
+    "tomli",
+]
 
 [project.scripts]
 mkv-cleaner = "mkv_cleaner:main"


### PR DESCRIPTION
## Summary
- add `tomli` requirement to pyproject for Python versions below 3.11
- mention `tomli` in README dependencies list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f5a7362c8323b91f455bc680c6bb