### PR TITLE
Handle missing commands gracefully

### DIFF
--- a/core/tracks.py
+++ b/core/tracks.py
@@ -31,10 +31,18 @@ class Track:
             f"{self.language}-{'F' if self.forced else ''}-{self.name}"
         )
 
+class CommandNotFoundError(RuntimeError):
+    """Raised when an external command is missing."""
+
+
 def run_command(cmd: list[str]) -> subprocess.CompletedProcess:
-    logger.debug(f"Running: {' '.join(cmd)}")
+    logger.debug("Running: %s", " ".join(cmd))
     try:
         return subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        msg = f"{cmd[0]} not found on PATH"
+        logger.error(msg)
+        raise CommandNotFoundError(msg) from exc
     except subprocess.CalledProcessError as exc:
         logger.error("Command failed: %s\n%s", exc, exc.stderr)
         raise

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -1,0 +1,21 @@
+import logging
+import sys
+import os
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import core.tracks as tracks  # noqa: E402
+
+
+def test_run_command_missing(monkeypatch, caplog):
+    def fake_run(*a, **kw):
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(tracks.subprocess, "run", fake_run)
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(tracks.CommandNotFoundError):
+        tracks.run_command(["mkvmerge", "-J", str(Path("in.mkv"))])
+    assert "mkvmerge not found on PATH" in caplog.text
+


### PR DESCRIPTION
## Summary
- handle `FileNotFoundError` in `run_command`
- emit a clear error and raise new `CommandNotFoundError`
- add tests for command not found scenario

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f5dabf048323a9fa1239401847ea