### PR TITLE
Simplify TrackTableModel

### DIFF
--- a/gui/models.py
+++ b/gui/models.py
@@ -1,14 +1,13 @@
 from PySide6.QtCore import QAbstractTableModel, Qt, QModelIndex
+from core.tracks import Track
 
 
 class TrackTableModel(QAbstractTableModel):
-    def __init__(self, tracks=None):
+    def __init__(self, tracks: list[Track] | None = None):
         super().__init__()
-        self.tracks = tracks or []
+        self.tracks: list[Track] = tracks or []
 
     def rowCount(self, parent=QModelIndex()):
-        if isinstance(self.tracks, dict):
-            return len(self.tracks)
         return len(self.tracks)
 
     def columnCount(self, parent=QModelIndex()):
@@ -18,16 +17,9 @@ class TrackTableModel(QAbstractTableModel):
         if not index.isValid():
             return None
 
-        if isinstance(self.tracks, dict):
-            keys = sorted(self.tracks.keys())
-            if index.row() < 0 or index.row() >= len(keys):
-                return None
-            key = keys[index.row()]
-            t = self.tracks[key]
-        else:
-            if index.row() < 0 or index.row() >= len(self.tracks):
-                return None
-            t = self.tracks[index.row()]
+        if index.row() < 0 or index.row() >= len(self.tracks):
+            return None
+        t = self.tracks[index.row()]
 
         c = index.column()
         if role == Qt.CheckStateRole and c == 0:
@@ -50,11 +42,7 @@ class TrackTableModel(QAbstractTableModel):
 
     def setData(self, index, value, role=Qt.CheckStateRole):
         if index.isValid() and role == Qt.CheckStateRole and index.column() == 0:
-            if isinstance(self.tracks, dict):
-                keys = sorted(self.tracks.keys())
-                t = self.tracks[keys[index.row()]]
-            else:
-                t = self.tracks[index.row()]
+            t = self.tracks[index.row()]
             t.removed = value == Qt.Unchecked
             self.dataChanged.emit(index, index, [Qt.CheckStateRole])
             return True
@@ -84,12 +72,6 @@ class TrackTableModel(QAbstractTableModel):
         return self.tracks
 
     def track_at_row(self, row):
-        if isinstance(self.tracks, dict):
-            keys = sorted(self.tracks.keys())
-            if 0 <= row < len(keys):
-                return self.tracks[keys[row]]
-            raise KeyError(row)
-        else:
-            if 0 <= row < len(self.tracks):
-                return self.tracks[row]
-            raise IndexError(row)
+        if 0 <= row < len(self.tracks):
+            return self.tracks[row]
+        raise IndexError(row)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,58 @@
+import types
+import sys
+
+sys.modules['PySide6'] = types.ModuleType('PySide6')
+qtcore = types.ModuleType('PySide6.QtCore')
+qtcore.Qt = type('Qt', (), {
+    'Checked': 2,
+    'Unchecked': 0,
+    'CheckStateRole': 0,
+    'DisplayRole': 1,
+    'ItemIsEnabled': 1,
+    'ItemIsSelectable': 2,
+    'ItemIsUserCheckable': 4
+})
+qtcore.QAbstractTableModel = object
+qtcore.QModelIndex = object
+sys.modules['PySide6.QtCore'] = qtcore
+from PySide6.QtCore import Qt
+
+from gui.models import TrackTableModel
+from core.tracks import Track
+
+
+def test_track_table_model_basic():
+    tracks = [
+        Track(idx=0, tid=1, type="audio", codec="aac", language="eng", forced=False, name="English")
+    ]
+    model = TrackTableModel(tracks)
+    # Fake the Qt signal used in setData
+    model.dataChanged = type('sig', (), {'emit': lambda *a, **k: None})()
+    assert model.rowCount() == 1
+
+    class DummyIndex:
+        def __init__(self, row, column):
+            self._r = row
+            self._c = column
+        def row(self):
+            return self._r
+        def column(self):
+            return self._c
+        def isValid(self):
+            return 0 <= self._r and 0 <= self._c
+
+    idx = DummyIndex(0, 0)
+    assert model.data(idx, role=Qt.CheckStateRole) == Qt.Checked
+    model.setData(idx, Qt.Unchecked, Qt.CheckStateRole)
+    assert tracks[0].removed is True
+    assert model.data(idx, role=Qt.CheckStateRole) == Qt.Unchecked
+    assert model.track_at_row(0) is tracks[0]
+
+
+    try:
+        model.track_at_row(1)
+    except IndexError:
+        pass
+    else:
+        assert False, "expected IndexError"
+


### PR DESCRIPTION
## Summary
- simplify `TrackTableModel` to only handle `list[Track]`
- add basic unit test for the model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f5d1b1f88323937e474daf9840b9