### PR TITLE
Fix environment path for Windows workflow

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -47,9 +47,22 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         run: choco install ffmpeg mkvtoolnix --no-progress -y
 
+      - name: Refresh environment
+        if: steps.changes.outputs.changed == 'true'
+        shell: cmd
+        run: RefreshEnv
+
       - name: Build wheel and sdist
         if: steps.changes.outputs.changed == 'true'
         run: python -m build
+
+      - name: Verify tools on PATH
+        if: steps.changes.outputs.changed == 'true'
+        shell: cmd
+        run: |
+          where ffmpeg
+          where mkvmerge
+          where mkvextract
 
       - name: Build PyInstaller bundle
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Summary
- ensure FFmpeg and MKVToolNix paths refresh on Windows
- verify tools exist before bundling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fa54f0cc8323a877f80d8f946d48