### PR TITLE
Ensure packaging fails when mkvmerge is missing

### DIFF
--- a/mkv-cleaner.spec
+++ b/mkv-cleaner.spec
@@ -5,8 +5,9 @@ from PyInstaller.utils.hooks import collect_submodules
 binaries = []
 for exe in ("mkvmerge", "mkvextract", "ffmpeg", "ffprobe"):
     path = shutil.which(exe)
-    if path:
-        binaries.append((path, '.'))
+    if not path:
+        raise RuntimeError(f"Required executable '{exe}' not found on PATH")
+    binaries.append((path, '.'))
 
 hidden = collect_submodules('gui') + collect_submodules('core')
 


### PR DESCRIPTION
## Summary
- raise a `RuntimeError` in `mkv-cleaner.spec` when required tools are absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841facc53008323807da5be17f81e8f