### PR TITLE
Fix MKVToolNix PATH on Windows package workflow

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -47,10 +47,13 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         run: choco install ffmpeg mkvtoolnix --no-progress -y
 
-      - name: Refresh environment
+      - name: Add MKVToolNix to PATH
         if: steps.changes.outputs.changed == 'true'
-        shell: cmd
-        run: RefreshEnv
+        shell: pwsh
+        run: |
+          $installDir = Get-AppInstallLocation 'mkvtoolnix'
+          if (-not $installDir) { throw 'MKVToolNix installation not found' }
+          echo $installDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Build wheel and sdist
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Summary
- add a step to make MKVToolNix available on PATH
- drop the manual RefreshEnv step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fd54884883238ee85739c9bf3b9f