### PR TITLE
Check ffprobe in Windows CI

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -64,6 +64,7 @@ jobs:
         shell: cmd
         run: |
           where ffmpeg
+          where ffprobe
           where mkvmerge
           where mkvextract
 


### PR DESCRIPTION
## Summary
- ensure ffprobe is present during Windows packaging

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fec3fb6c8323a45fd46531be8906