### PR TITLE
Add ffprobe check to Windows workflow

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -64,6 +64,7 @@ jobs:
         shell: cmd
         run: |
           where ffmpeg
+          where ffprobe
           where mkvmerge
           where mkvextract
 


### PR DESCRIPTION
## Summary
- verify `ffprobe` executable exists in the Windows workflow to ensure all tools are on PATH

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684200895dec8323926e4ffe17b3eed9