### PR TITLE
Fix MKVToolNix path in Windows packaging

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -51,9 +51,11 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         shell: pwsh
         run: |
-          $mkvmerge = Get-Command mkvmerge.exe -ErrorAction Stop
-          $dir = Split-Path $mkvmerge.Path
-          Add-Content -Path $env:GITHUB_PATH -Value $dir
+          $mkvDir = Join-Path $Env:ProgramFiles 'MKVToolNix'
+          if (-not (Test-Path (Join-Path $mkvDir 'mkvmerge.exe'))) {
+            throw 'mkvmerge.exe not found'
+          }
+          Add-Content -Path $Env:GITHUB_PATH -Value $mkvDir
 
       - name: Build wheel and sdist
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Summary
- ensure mkvtoolnix binaries are added to PATH on Windows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684201ace24083238e32197265ac97e0