### PR TITLE
Add bootstrap module for auto dependency download

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,19 @@ MKV Cleaner is an easy-to-use GUI for tidying Matroska (`.mkv`) files. You can q
 
 ## Dependencies
 
-When running from source you need to install the following tools yourself:
+When running from source the application will try to download missing command
+line tools and install Python packages automatically. You only need to ensure
+`pip` can install packages. The following tools are used:
 
 - [Python 3.10 or later](https://www.python.org/downloads/)
 - [PySide6](https://pypi.org/project/PySide6/)
 - [tomli](https://pypi.org/project/tomli/) *(for Python < 3.11)*
 - [MKVToolNix](https://mkvtoolnix.download/) (`mkvmerge` and `mkvextract` on your `PATH`) *(optional if using FFmpeg)*
 - [FFmpeg](https://ffmpeg.org/) (`ffmpeg` and `ffprobe` on your `PATH` if selected)
+
+Missing binaries (`mkvmerge`, `mkvextract`, `ffmpeg`, `ffprobe`) will be
+downloaded to the application directory on first launch if they cannot be
+found, and Python packages will be installed automatically.
 
 The prebuilt bundles published in the GitHub releases already include PySide6,
 FFmpeg and MKVToolNix so no additional installation is required. Copies of

--- a/core/bootstrap.py
+++ b/core/bootstrap.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+# Directory containing ``mkv_cleaner.py``
+APP_DIR = Path(__file__).resolve().parents[1]
+
+
+def ensure_binary(exe_name: str, url: str) -> str:
+    """Ensure ``exe_name`` exists next to ``mkv_cleaner.py``.
+
+    If the executable is missing it will be downloaded from ``url`` which is
+    expected to be an archive containing the program. The executable is
+    extracted and its local path is returned.
+    """
+    exe_path = APP_DIR / exe_name
+    if exe_path.exists():
+        return str(exe_path)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        suffix = Path(url).suffix or '.zip'
+        archive = Path(tmpdir) / f"download{suffix}"
+        urllib.request.urlretrieve(url, archive)
+        shutil.unpack_archive(str(archive), tmpdir)
+
+        found = None
+        for root, _, files in os.walk(tmpdir):
+            if exe_name in files:
+                found = Path(root) / exe_name
+                break
+        if not found:
+            raise FileNotFoundError(f"{exe_name} not found in archive")
+        shutil.copy2(found, exe_path)
+        exe_path.chmod(0o755)
+
+    return str(exe_path)
+
+
+def ensure_python_package(pkg: str) -> None:
+    """Import ``pkg`` or install it via ``pip`` if missing."""
+    try:
+        __import__(pkg)
+    except ImportError:
+        subprocess.run([sys.executable, "-m", "pip", "install", pkg], check=True)
+

--- a/core/config.py
+++ b/core/config.py
@@ -7,6 +7,8 @@ import json
 import os
 import sys
 
+from core.bootstrap import ensure_binary
+
 try:  # Python >=3.11
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - fallback for older versions
@@ -20,10 +22,24 @@ if getattr(sys, 'frozen', False):  # Running from PyInstaller bundle
     FFMPEG = str(bindir / f"ffmpeg{ext}")
     FFPROBE = str(bindir / f"ffprobe{ext}")
 else:
-    MKVMERGE = "mkvmerge"
-    MKVEXTRACT = "mkvextract"
-    FFMPEG = "ffmpeg"
-    FFPROBE = "ffprobe"
+    ext = '.exe' if os.name == 'nt' else ''
+    if os.environ.get('MKVCLEANER_SKIP_BOOTSTRAP'):
+        MKVMERGE = f"mkvmerge{ext}"
+        MKVEXTRACT = f"mkvextract{ext}"
+        FFMPEG = f"ffmpeg{ext}"
+        FFPROBE = f"ffprobe{ext}"
+    else:
+        if os.name == 'nt':
+            mkv_url = 'https://mkvtoolnix.download/windows/latest-release/mkvtoolnix-cli.zip'
+            ff_url = 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip'
+        else:
+            mkv_url = 'https://mkvtoolnix.download/linux/latest-release/mkvtoolnix-cli.tar.xz'
+            ff_url = 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz'
+
+        MKVMERGE = ensure_binary(f"mkvmerge{ext}", mkv_url)
+        MKVEXTRACT = ensure_binary(f"mkvextract{ext}", mkv_url)
+        FFMPEG = ensure_binary(f"ffmpeg{ext}", ff_url)
+        FFPROBE = ensure_binary(f"ffprobe{ext}", ff_url)
 
 DEFAULTS: Dict[str, Any] = {
     "backend": "mkvtoolnix",  # or "ffmpeg"

--- a/mkv_cleaner.py
+++ b/mkv_cleaner.py
@@ -5,11 +5,18 @@ randomized modern style and opens the main window. Run the ``mkv-cleaner``
 console script or execute this module directly to launch the application.
 """
 
+import sys
+import random
+
+from core.bootstrap import ensure_python_package
+
+ensure_python_package('PySide6')
+if sys.version_info < (3, 11):
+    ensure_python_package('tomli')
+
 from gui.main_window import MainWindow
 from gui.widgets.fast_tooltip_style import FastToolTipStyle
 from PySide6.QtWidgets import QApplication
-import sys
-import random
 
 def set_dynamic_modern_style(app: QApplication) -> None:
     """Apply a dark theme with a random accent color to ``app``."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault('MKVCLEANER_SKIP_BOOTSTRAP', '1')
+
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,71 @@
+import builtins
+import os
+import shutil
+import sys
+import zipfile
+from pathlib import Path
+import importlib
+
+import core.bootstrap as bootstrap
+
+
+def test_ensure_binary_download(monkeypatch, tmp_path):
+    exe = 'tool.exe' if os.name == 'nt' else 'tool'
+    archive = tmp_path / 'a.zip'
+    with zipfile.ZipFile(archive, 'w') as z:
+        z.writestr(exe, 'x')
+
+    calls = []
+
+    def fake_urlretrieve(url, filename):
+        shutil.copy(archive, filename)
+        calls.append(url)
+
+    monkeypatch.setattr(bootstrap, 'APP_DIR', tmp_path)
+    monkeypatch.setattr(bootstrap.urllib.request, 'urlretrieve', fake_urlretrieve)
+
+    path = bootstrap.ensure_binary(exe, 'http://example/archive.zip')
+    assert Path(path) == tmp_path / exe
+    assert (tmp_path / exe).exists()
+    assert calls
+
+    calls.clear()
+    bootstrap.ensure_binary(exe, 'http://example/archive.zip')
+    assert not calls
+
+
+def test_ensure_python_package(monkeypatch):
+    orig_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == 'somepkg':
+            raise ImportError
+        return orig_import(name, globals, locals, fromlist, level)
+
+    called = {}
+
+    def fake_run(cmd, check):
+        called['cmd'] = cmd
+        called['check'] = check
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+    monkeypatch.setattr(bootstrap.subprocess, 'run', fake_run)
+
+    bootstrap.ensure_python_package('somepkg')
+    assert called['cmd'][0] == sys.executable
+
+
+def test_config_uses_local_binaries(monkeypatch):
+    import core.config as config
+    monkeypatch.delenv('MKVCLEANER_SKIP_BOOTSTRAP', raising=False)
+    monkeypatch.setattr(bootstrap, 'ensure_binary', lambda exe, url: f'/tmp/{exe}')
+    import importlib
+    importlib.reload(config)
+    ext = '.exe' if os.name == 'nt' else ''
+    assert config.MKVMERGE == f'/tmp/mkvmerge{ext}'
+    assert config.DEFAULTS['mkvmerge_cmd'] == f'/tmp/mkvmerge{ext}'
+    assert config.DEFAULTS['ffmpeg_cmd'] == f'/tmp/ffmpeg{ext}'
+
+    monkeypatch.setenv('MKVCLEANER_SKIP_BOOTSTRAP', '1')
+    importlib.reload(config)
+


### PR DESCRIPTION
## Summary
- ensure local binaries and packages with new bootstrap utilities
- update config to download missing executables
- pre-load required python packages in entry point
- document automatic installation
- test bootstrap functions and integration

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e1de9994832389677ecf14ba25aa