### PR TITLE
Default to FFmpeg backend

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -43,19 +43,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install build pyinstaller pyside6
 
-      - name: Install FFmpeg and MKVToolNix
+      - name: Install FFmpeg
         if: steps.changes.outputs.changed == 'true'
-        run: choco install ffmpeg mkvtoolnix --no-progress -y
+        run: choco install ffmpeg --no-progress -y
 
-      - name: Add MKVToolNix to PATH
-        if: steps.changes.outputs.changed == 'true'
-        shell: pwsh
-        run: |
-          $mkvDir = Join-Path $Env:ProgramFiles 'MKVToolNix'
-          if (-not (Test-Path (Join-Path $mkvDir 'mkvmerge.exe'))) {
-            throw 'mkvmerge.exe not found'
-          }
-          Add-Content -Path $Env:GITHUB_PATH -Value $mkvDir
 
       - name: Build wheel and sdist
         if: steps.changes.outputs.changed == 'true'
@@ -67,8 +58,6 @@ jobs:
         run: |
           where ffmpeg
           where ffprobe
-          where mkvmerge
-          where mkvextract
 
       - name: Build PyInstaller bundle
         if: steps.changes.outputs.changed == 'true'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ MKV Cleaner is an easy-to-use GUI for tidying Matroska (`.mkv`) files. You can q
 - **Drop unneeded tracks** – remove audio or subtitle tracks you don't want
 - **Control default and forced flags** for audio and subtitle tracks
 - **Subtitle preview** lets you inspect text before processing
-- **Flexible backend** – work with either MKVToolNix or FFmpeg
+- **Flexible backend** – work with either MKVToolNix or FFmpeg (FFmpeg is the default)
 - **Self-contained bundles** ship with all required dependencies
 
 ## Dependencies
@@ -30,9 +30,9 @@ Missing binaries (`mkvmerge`, `mkvextract`, `ffmpeg`, `ffprobe`) will be
 downloaded to the application directory on first launch if they cannot be
 found, and Python packages will be installed automatically.
 
-The prebuilt bundles published in the GitHub releases already include PySide6,
-FFmpeg and MKVToolNix so no additional installation is required. Copies of
-their licenses are distributed alongside the bundle.
+The prebuilt bundles published in the GitHub releases already include PySide6
+and FFmpeg so no additional installation is required. Copies of their licenses
+are distributed alongside the bundle.
 
 ## Downloads
 

--- a/core/config.py
+++ b/core/config.py
@@ -42,7 +42,7 @@ else:
         FFPROBE = ensure_binary(f"ffprobe{ext}", ff_url)
 
 DEFAULTS: Dict[str, Any] = {
-    "backend": "mkvtoolnix",  # or "ffmpeg"
+    "backend": "ffmpeg",  # or "mkvtoolnix"
     "mkvmerge_cmd": MKVMERGE,
     "mkvextract_cmd": MKVEXTRACT,
     "ffmpeg_cmd": FFMPEG,

--- a/gui/actions_logic.py
+++ b/gui/actions_logic.py
@@ -96,7 +96,7 @@ class ActionsLogic:
             t.name,
             run_command,
             DEFAULTS["ffmpeg_cmd"] if DEFAULTS.get("backend") == "ffmpeg" else DEFAULTS["mkvextract_cmd"],
-            DEFAULTS.get("backend", "mkvtoolnix"),
+            DEFAULTS.get("backend", "ffmpeg"),
             parent=self,
         )
         self._preview_win.show()

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -14,7 +14,7 @@ class PreferencesDialog(QDialog):
 
         self.backend = QComboBox(self)
         self.backend.addItems(["mkvtoolnix", "ffmpeg"])
-        self.backend.setCurrentText(self.settings.value("backend", "mkvtoolnix"))
+        self.backend.setCurrentText(self.settings.value("backend", "ffmpeg"))
         layout.addRow("Backend:", self.backend)
 
         self.merge_path = QLineEdit(self)

--- a/gui/settings_logic.py
+++ b/gui/settings_logic.py
@@ -15,7 +15,7 @@ class SettingsLogic:
         if hasattr(self, "menu_preferences"):
             self.menu_preferences.triggered.connect(self._open_preferences)
         if hasattr(self, "group_bar") and hasattr(self.group_bar, "backend_combo"):
-            self.group_bar.set_backend(DEFAULTS.get("backend", "mkvtoolnix"))
+            self.group_bar.set_backend(DEFAULTS.get("backend", "ffmpeg"))
             self.group_bar.backendChanged.connect(self._change_backend)
 
     def _load_preferences(self):
@@ -30,7 +30,7 @@ class SettingsLogic:
         self.last_input_dir   = self.settings.value("last_input_dir", "", type=str)
         self.wipe_all_default = self.settings.value("wipe_all_default", False, type=bool)
         if hasattr(self, "group_bar") and hasattr(self.group_bar, "set_backend"):
-            self.group_bar.set_backend(DEFAULTS.get("backend", "mkvtoolnix"))
+            self.group_bar.set_backend(DEFAULTS.get("backend", "ffmpeg"))
 
     def _open_preferences(self):
         dlg = PreferencesDialog(self)

--- a/gui/widgets/group_bar.py
+++ b/gui/widgets/group_bar.py
@@ -38,7 +38,7 @@ class GroupBar(QWidget):
 
         self.backend_combo = QComboBox(self)
         self.backend_combo.addItems(["mkvtoolnix", "ffmpeg"])
-        self.backend_combo.setCurrentText(DEFAULTS.get("backend", "mkvtoolnix"))
+        self.backend_combo.setCurrentText(DEFAULTS.get("backend", "ffmpeg"))
         self.backend_combo.setToolTip("Select backend")
         self.backend_combo.currentTextChanged.connect(self.backendChanged.emit)
         self.backend_combo.setFixedHeight(32)

--- a/mkv-cleaner.spec
+++ b/mkv-cleaner.spec
@@ -3,7 +3,7 @@ import sys
 from PyInstaller.utils.hooks import collect_submodules
 
 binaries = []
-for exe in ("mkvmerge", "mkvextract", "ffmpeg", "ffprobe"):
+for exe in ("ffmpeg", "ffprobe"):
     path = shutil.which(exe)
     if not path:
         raise RuntimeError(f"Required executable '{exe}' not found on PATH")


### PR DESCRIPTION
## Summary
- switch the default backend to FFmpeg
- ship only FFmpeg in PyInstaller bundle
- remove MKVToolNix install from Windows packaging workflow
- document new default in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e563e8908323a9f6bbac8b4b84fc