### PR TITLE
Add language flag support

### DIFF
--- a/core/flags.py
+++ b/core/flags.py
@@ -1,0 +1,90 @@
+# Simple mapping from language codes to flag emojis
+# Supports both 2-letter and 3-letter language codes
+
+_LANG_TO_COUNTRY = {
+    # English
+    "en": "GB",
+    "eng": "GB",
+    # Spanish
+    "es": "ES",
+    "spa": "ES",
+    # German
+    "de": "DE",
+    "deu": "DE",
+    # French
+    "fr": "FR",
+    "fra": "FR",
+    # Italian
+    "it": "IT",
+    "ita": "IT",
+    # Portuguese
+    "pt": "PT",
+    "por": "PT",
+    # Russian
+    "ru": "RU",
+    "rus": "RU",
+    # Japanese
+    "ja": "JP",
+    "jpn": "JP",
+    # Chinese
+    "zh": "CN",
+    "zho": "CN",
+    "chi": "CN",
+    # Persian (Farsi)
+    "fa": "IR",
+    "fas": "IR",
+    "per": "IR",
+    # Arabic
+    "ar": "SA",
+    "ara": "SA",
+    # Dutch
+    "nl": "NL",
+    "nld": "NL",
+    "dut": "NL",
+    # Polish
+    "pl": "PL",
+    "pol": "PL",
+    # Turkish
+    "tr": "TR",
+    "tur": "TR",
+    # Korean
+    "ko": "KR",
+    "kor": "KR",
+    # Hindi
+    "hi": "IN",
+    "hin": "IN",
+    # Vietnamese
+    "vi": "VN",
+    "vie": "VN",
+    # Swedish
+    "sv": "SE",
+    "swe": "SE",
+    # Greek
+    "el": "GR",
+    "ell": "GR",
+    "gre": "GR",
+    # Hebrew
+    "he": "IL",
+    "heb": "IL",
+    # Thai
+    "th": "TH",
+    "tha": "TH",
+}
+
+
+def _country_code_to_flag(cc: str) -> str:
+    """Convert a 2-letter country code to an emoji flag."""
+    if len(cc) != 2:
+        return ""
+    return chr(127397 + ord(cc[0].upper())) + chr(127397 + ord(cc[1].upper()))
+
+
+def lang_to_flag(lang: str) -> str:
+    """Return an emoji flag for the given language code if known."""
+    if not lang:
+        return ""
+    lang = lang.lower()
+    cc = _LANG_TO_COUNTRY.get(lang)
+    if cc:
+        return _country_code_to_flag(cc)
+    return ""

--- a/gui/models.py
+++ b/gui/models.py
@@ -1,5 +1,6 @@
 from PySide6.QtCore import QAbstractTableModel, Qt, QModelIndex
 from core.tracks import Track
+from core.flags import lang_to_flag
 
 
 class TrackTableModel(QAbstractTableModel):
@@ -29,7 +30,11 @@ class TrackTableModel(QAbstractTableModel):
                 1: getattr(t, "tid", ""),
                 2: getattr(t, "type", ""),
                 3: getattr(t, "codec", ""),
-                4: getattr(t, "language", ""),
+                4: (
+                    lang_to_flag(getattr(t, "language", ""))
+                    if t.type in {"audio", "subtitles"}
+                    else getattr(t, "language", "")
+                ),
                 5: "🚩" if getattr(t, "forced", False) else "",
                 6: (
                     "🔊"

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,0 +1,13 @@
+from core.flags import lang_to_flag
+
+
+def test_lang_to_flag_known_codes():
+    assert lang_to_flag('eng') == lang_to_flag('en') == '🇬🇧'
+    assert lang_to_flag('spa') == '🇪🇸'
+    assert lang_to_flag('deu') == '🇩🇪'
+    assert lang_to_flag('fas') == lang_to_flag('fa') == '🇮🇷'
+    assert lang_to_flag('pol') == '🇵🇱'
+
+
+def test_lang_to_flag_unknown():
+    assert lang_to_flag('xxx') == ''


### PR DESCRIPTION
## Summary
- show flag emoji for audio and subtitle language codes
- add mapping utility for converting language codes to flags
- expand mapping to include more languages like Persian
- test language flag conversion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842e6eb648c8323a372b4206fd1b6a1