### PR TITLE
Handle ffprobe DLLs on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ are distributed alongside the bundle.
 
 New bundles are uploaded manually through a GitHub workflow whenever changes are ready. Download the archive for your platform from the Releases section and run the `mkv-cleaner` executable contained inside.
 
+## Packaging
+
+Build a self-contained bundle with:
+
+```bash
+pyinstaller mkv-cleaner.spec
+```
+
+When packaging on Windows the spec file collects any DLLs located next to
+`ffprobe` (for example in `ffmpeg\bin`) so the bundled executable can run
+`ffprobe` without requiring FFmpeg to be installed separately.
+
 
 ## Usage
 

--- a/mkv-cleaner.spec
+++ b/mkv-cleaner.spec
@@ -1,5 +1,6 @@
 import shutil
 import sys
+from pathlib import Path
 from PyInstaller.utils.hooks import collect_submodules
 
 binaries = []
@@ -8,6 +9,19 @@ for exe in ("ffmpeg", "ffprobe"):
     if not path:
         raise RuntimeError(f"Required executable '{exe}' not found on PATH")
     binaries.append((path, '.'))
+
+# On Windows we also need the DLLs shipped with ffprobe
+if sys.platform == "win32":
+    ffprobe_path = shutil.which("ffprobe")
+    if ffprobe_path:
+        base = Path(ffprobe_path).resolve().parent
+        search_dirs = [base]
+        bin_dir = base / "bin"
+        if bin_dir.is_dir():
+            search_dirs.append(bin_dir)
+        for directory in search_dirs:
+            for dll in directory.glob("*.dll"):
+                binaries.append((str(dll), '.'))
 
 hidden = collect_submodules('gui') + collect_submodules('core')
 


### PR DESCRIPTION
## Summary
- include ffprobe DLLs when building on Windows
- document building the bundle in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842ef9404c4832382ce5d934fbd3dc1