### PR TITLE
Handle ffprobe DLLs on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ are distributed alongside the bundle.
 
 New bundles are uploaded manually through a GitHub workflow whenever changes are ready. Download the archive for your platform from the Releases section and run the `mkv-cleaner` executable contained inside.
 
+## Packaging
+
+Build a self-contained bundle with:
+
+```bash
+pyinstaller mkv-cleaner.spec
+```
+
+When packaging on Windows the spec file collects all DLLs from the directory
+containing `ffprobe` (and a `bin` subdirectory if present) so the bundled
+executable can run `ffprobe` without requiring FFmpeg to be installed
+separately.
+
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- include ffprobe DLLs when building on Windows
- document building the bundle in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842ef9404c4832382ce5d934fbd3dc1