### PR TITLE
Fix windows packaging spec

### DIFF
--- a/mkv-cleaner.spec
+++ b/mkv-cleaner.spec
@@ -20,7 +20,6 @@ if sys.platform == "win32":
         if bin_dir.is_dir():
             search_dirs.append(bin_dir)
         for directory in search_dirs:
-codex/update-mkv-cleaner.spec-for-ffprobe-dlls
             for dll in directory.glob("*.dll"):
                 binaries.append((str(dll), '.'))
 


### PR DESCRIPTION
## Summary
- fix stray line in mkv-cleaner.spec that broke pyinstaller

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f3edff688323b52aeb1ab6a3fb60