### PR TITLE
Add KeepToggleDelegate for track table

### DIFF
--- a/gui/widgets/keep_toggle_delegate.py
+++ b/gui/widgets/keep_toggle_delegate.py
@@ -1,0 +1,31 @@
+from PySide6.QtWidgets import QStyledItemDelegate
+from PySide6.QtGui import QColor
+from PySide6.QtCore import Qt, QEvent
+
+
+class KeepToggleDelegate(QStyledItemDelegate):
+    """Delegate that paints a full cell toggle for keeping/removing tracks."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.checked_color = QColor("#3584e4")
+        self.unchecked_color = QColor("#2a2c34")
+        self.hover_color = QColor("#51a4fc")
+
+    def paint(self, painter, option, index):
+        state = index.data(Qt.CheckStateRole)
+        if option.state & option.State_MouseOver:
+            color = self.hover_color
+        elif state == Qt.Checked:
+            color = self.checked_color
+        else:
+            color = self.unchecked_color
+        painter.fillRect(option.rect, color)
+
+    def editorEvent(self, event, model, option, index):
+        if event.type() == QEvent.MouseButtonRelease and option.rect.contains(event.pos()):
+            current = index.data(Qt.CheckStateRole)
+            new_state = Qt.Unchecked if current == Qt.Checked else Qt.Checked
+            model.setData(index, new_state, Qt.CheckStateRole)
+            return True
+        return super().editorEvent(event, model, option, index)

--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -1,8 +1,10 @@
 from PySide6.QtWidgets import QTableView
 from gui.models import TrackTableModel
+from .keep_toggle_delegate import KeepToggleDelegate
 
 class TrackTable(QTableView):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.model = TrackTableModel()
         self.setModel(self.model)
+        self.setItemDelegateForColumn(0, KeepToggleDelegate(self))


### PR DESCRIPTION
## Summary
- add `KeepToggleDelegate` to paint a colored toggle cell
- use the delegate for column 0 of `TrackTable`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430a3178e08323a32fe68d7339e9c6