### PR TITLE
Center align headers and cells

### DIFF
--- a/gui/models.py
+++ b/gui/models.py
@@ -23,6 +23,8 @@ class TrackTableModel(QAbstractTableModel):
         t = self.tracks[index.row()]
 
         c = index.column()
+        if role == getattr(Qt, "TextAlignmentRole", None):
+            return getattr(Qt, "AlignCenter", 0)
         if role == Qt.CheckStateRole and c == 0:
             return Qt.Checked if not getattr(t, "removed", False) else Qt.Unchecked
         if role == Qt.DisplayRole:
@@ -62,10 +64,13 @@ class TrackTableModel(QAbstractTableModel):
         return base
 
     def headerData(self, section, orientation, role=Qt.DisplayRole):
-        if orientation == Qt.Horizontal and role == Qt.DisplayRole:
-            return ["Keep", "ID", "Type", "Codec", "Lang", "Forced", "Default", "Name"][
-                section
-            ]
+        if orientation == Qt.Horizontal:
+            if role == Qt.DisplayRole:
+                return ["Keep", "ID", "Type", "Codec", "Lang", "Forced", "Default", "Name"][
+                    section
+                ]
+            if role == getattr(Qt, "TextAlignmentRole", None):
+                return getattr(Qt, "AlignCenter", 0)
         return super().headerData(section, orientation, role)
 
     def update_tracks(self, tracks):

--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -1,4 +1,5 @@
 from PySide6.QtWidgets import QTableView
+from PySide6.QtCore import Qt
 from gui.models import TrackTableModel
 
 class TrackTable(QTableView):
@@ -6,3 +7,4 @@ class TrackTable(QTableView):
         super().__init__(parent)
         self.model = TrackTableModel()
         self.setModel(self.model)
+        self.horizontalHeader().setDefaultAlignment(getattr(Qt, "AlignCenter", 0))


### PR DESCRIPTION
## Summary
- handle `Qt.TextAlignmentRole` in data and headerData
- center header text in `TrackTable`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68430a2101788323842c676a4f8ea1fb