### PR TITLE
Add loglevel flag to ffmpeg command

### DIFF
--- a/core/tracks.py
+++ b/core/tracks.py
@@ -165,7 +165,15 @@ def _build_cmd_ffmpeg(
     wipe_forced: bool,
     wipe_all: bool,
 ) -> list[str]:
-    cmd: list[str] = [DEFAULTS["ffmpeg_cmd"], "-i", str(source), "-map", "0"]
+    cmd: list[str] = [
+        DEFAULTS["ffmpeg_cmd"],
+        "-loglevel",
+        "error",
+        "-i",
+        str(source),
+        "-map",
+        "0",
+    ]
 
     for t in tracks:
         if t.type in {"audio", "subtitles"}:

--- a/tests/test_tracks.py
+++ b/tests/test_tracks.py
@@ -51,6 +51,8 @@ def test_build_cmd_flags(defaults):
     cmd = build_cmd(src, dst, tracks, wipe_forced=True, wipe_all=False)
     assert cmd == [
         "ffmpeg",
+        "-loglevel",
+        "error",
         "-i",
         str(src),
         "-map",
@@ -110,6 +112,8 @@ def test_build_cmd_wipe_all(defaults):
     cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=True)
     assert cmd == [
         "ffmpeg",
+        "-loglevel",
+        "error",
         "-i",
         str(src),
         "-map",
@@ -168,6 +172,8 @@ def test_build_cmd_forced_default_ffmpeg(defaults):
     cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=False)
     assert cmd == [
         "ffmpeg",
+        "-loglevel",
+        "error",
         "-i",
         str(src),
         "-map",


### PR DESCRIPTION
## Summary
- make ffmpeg run quieter by specifying `-loglevel error`
- update expected command lists in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430e702aa88323a4b0f5efaf44f24e