### PR TITLE
Add optional capture flag to run_command

### DIFF
--- a/core/tracks.py
+++ b/core/tracks.py
@@ -33,10 +33,12 @@ class CommandNotFoundError(RuntimeError):
     """Raised when an external command is missing."""
 
 
-def run_command(cmd: list[str]) -> subprocess.CompletedProcess:
+def run_command(cmd: list[str], capture: bool = True) -> subprocess.CompletedProcess:
     logger.debug("Running: %s", " ".join(cmd))
     try:
-        return subprocess.run(cmd, check=True, capture_output=True, text=True)
+        if capture:
+            return subprocess.run(cmd, check=True, capture_output=True, text=True)
+        return subprocess.run(cmd, check=True)
     except FileNotFoundError as exc:
         msg = f"{cmd[0]} not found on PATH"
         logger.error(msg)

--- a/gui/processing.py
+++ b/gui/processing.py
@@ -40,7 +40,7 @@ def process_files(jobs, max_workers, query_tracks, build_cmd, run_command, outpu
         cmd = build_cmd(src, dst, real_tracks, wipe_forced=False, wipe_all=wipe_all_flag)
         logger.info("Running: %s", " ".join(map(str, cmd)))
         try:
-            run_command(cmd)
+            run_command(cmd, capture=False)
         except Exception as e:
             with lock:
                 errors.append((str(src), str(e)))

--- a/gui/subtitle_preview.py
+++ b/gui/subtitle_preview.py
@@ -27,9 +27,9 @@ def peek_subtitle(fp: Path, tid: int, run_command, extract_cmd, backend, maxlen=
                 "-map",
                 f"0:{tid}",
                 tmp.name,
-            ])
+            ], capture=False)
         else:
-            run_command([extract_cmd, "tracks", str(fp), f"{tid}:{tmp.name}"])
+            run_command([extract_cmd, "tracks", str(fp), f"{tid}:{tmp.name}"], capture=False)
         try:
             out = Path(tmp.name).read_text(encoding="utf-8")[:maxlen]
         except UnicodeDecodeError:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -99,8 +99,8 @@ def test_cancel_shutdown(monkeypatch):
     def build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=False):
         return ["cmd", str(src), str(dst)]
 
-    def run_command(cmd):
-        commands.append(cmd)
+    def run_command(cmd, capture=True):
+        commands.append((cmd, capture))
 
     dlg = DummyDialog()
 
@@ -116,6 +116,7 @@ def test_cancel_shutdown(monkeypatch):
                              output_dir="out", wipe_all_flag=False)
 
     assert len(commands) == 1
+    assert commands[0][1] is False
     assert exec_instance.shutdown_called.get("cancel_futures") is True
 
 
@@ -129,8 +130,8 @@ def test_output_dir_created(monkeypatch, tmp_path):
     def build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=False):
         return ["cmd", str(src), str(dst)]
 
-    def run_command(cmd):
-        commands.append(cmd)
+    def run_command(cmd, capture=True):
+        commands.append((cmd, capture))
 
     dlg = DummyDialog()
 
@@ -156,3 +157,4 @@ def test_output_dir_created(monkeypatch, tmp_path):
     )
 
     assert (tmp_path / "out" / "sub").is_dir()
+    assert commands and commands[0][1] is False

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -2,6 +2,7 @@ import logging
 import sys
 import os
 from pathlib import Path
+import subprocess
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -18,4 +19,29 @@ def test_run_command_missing(monkeypatch, caplog):
     with pytest.raises(tracks.CommandNotFoundError):
         tracks.run_command(["mkvmerge", "-J", str(Path("in.mkv"))])
     assert "mkvmerge not found on PATH" in caplog.text
+
+
+def test_run_command_capture(monkeypatch):
+    called = {}
+
+    def fake_run(cmd, **kw):
+        called.update(kw)
+        return subprocess.CompletedProcess(cmd, 0, stdout="out", stderr="")
+
+    monkeypatch.setattr(tracks.subprocess, "run", fake_run)
+    res = tracks.run_command(["echo", "hi"])
+    assert called.get("capture_output") is True
+    assert res.stdout == "out"
+
+
+def test_run_command_no_capture(monkeypatch):
+    called = {}
+
+    def fake_run(cmd, **kw):
+        called.update(kw)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(tracks.subprocess, "run", fake_run)
+    tracks.run_command(["echo", "hi"], capture=False)
+    assert "capture_output" not in called
 


### PR DESCRIPTION
## Summary
- allow `core.tracks.run_command` to disable output capture
- stream output when processing or previewing subtitles
- test both capture behaviours
- adjust processing tests for new `run_command` signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430e59c09c83238a1bf51b8f6f3031