### PR TITLE
Add MKVCLEANER_SKIP_BOOTSTRAP checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Run the unit tests with:
 pytest
 ```
 
+Set the environment variable `MKVCLEANER_SKIP_BOOTSTRAP=1` to disable
+automatic downloads and package installation when running tests or
+using the application in offline environments.
+
 
 ## License
 

--- a/core/bootstrap.py
+++ b/core/bootstrap.py
@@ -11,6 +11,9 @@ from pathlib import Path
 # Directory containing ``mkv_cleaner.py``
 APP_DIR = Path(__file__).resolve().parents[1]
 
+# Environment variable to skip downloads/installations
+SKIP_BOOTSTRAP = os.environ.get("MKVCLEANER_SKIP_BOOTSTRAP")
+
 
 def ensure_binary(exe_name: str, url: str) -> str:
     """Ensure ``exe_name`` exists next to ``mkv_cleaner.py``.
@@ -20,6 +23,8 @@ def ensure_binary(exe_name: str, url: str) -> str:
     extracted and its local path is returned.
     """
     exe_path = APP_DIR / exe_name
+    if SKIP_BOOTSTRAP:
+        return str(exe_path)
     if exe_path.exists():
         return str(exe_path)
 
@@ -44,6 +49,8 @@ def ensure_binary(exe_name: str, url: str) -> str:
 
 def ensure_python_package(pkg: str) -> None:
     """Import ``pkg`` or install it via ``pip`` if missing."""
+    if SKIP_BOOTSTRAP:
+        return
     try:
         __import__(pkg)
     except ImportError:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -10,6 +10,8 @@ import core.bootstrap as bootstrap
 
 
 def test_ensure_binary_download(monkeypatch, tmp_path):
+    monkeypatch.delenv('MKVCLEANER_SKIP_BOOTSTRAP', raising=False)
+    monkeypatch.setattr(bootstrap, 'SKIP_BOOTSTRAP', None)
     exe = 'tool.exe' if os.name == 'nt' else 'tool'
     archive = tmp_path / 'a.zip'
     with zipfile.ZipFile(archive, 'w') as z:
@@ -35,6 +37,8 @@ def test_ensure_binary_download(monkeypatch, tmp_path):
 
 
 def test_ensure_python_package(monkeypatch):
+    monkeypatch.delenv('MKVCLEANER_SKIP_BOOTSTRAP', raising=False)
+    monkeypatch.setattr(bootstrap, 'SKIP_BOOTSTRAP', None)
     orig_import = builtins.__import__
 
     def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
@@ -68,4 +72,36 @@ def test_config_uses_system_binaries(monkeypatch):
     assert config.DEFAULTS['mkvmerge_cmd'] == f'mkvmerge{ext}'
     assert config.DEFAULTS['ffmpeg_cmd'] == f'ffmpeg{ext}'
     assert not called
+
+
+def test_skip_ensure_binary(monkeypatch, tmp_path):
+    exe = 'tool.exe' if os.name == 'nt' else 'tool'
+    monkeypatch.setattr(bootstrap, 'APP_DIR', tmp_path)
+    monkeypatch.setattr(bootstrap, 'SKIP_BOOTSTRAP', '1')
+
+    called = []
+
+    def fake_urlretrieve(url, filename):
+        called.append(True)
+
+    monkeypatch.setattr(bootstrap.urllib.request, 'urlretrieve', fake_urlretrieve)
+    monkeypatch.setenv('MKVCLEANER_SKIP_BOOTSTRAP', '1')
+
+    path = bootstrap.ensure_binary(exe, 'http://example/archive.zip')
+    assert Path(path) == tmp_path / exe
+    assert not called
+
+
+def test_skip_ensure_python_package(monkeypatch):
+    monkeypatch.setattr(bootstrap, 'SKIP_BOOTSTRAP', '1')
+    monkeypatch.setenv('MKVCLEANER_SKIP_BOOTSTRAP', '1')
+    called = {}
+
+    def fake_run(cmd, check):
+        called['run'] = True
+
+    monkeypatch.setattr(bootstrap.subprocess, 'run', fake_run)
+
+    bootstrap.ensure_python_package('somepkg')
+    assert 'run' not in called
 


### PR DESCRIPTION
## Summary
- skip download and pip installs in bootstrap when MKVCLEANER_SKIP_BOOTSTRAP is set
- document MKVCLEANER_SKIP_BOOTSTRAP in README
- update tests for new environment variable behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430e6eee808323abad2b25865513a5