### PR TITLE
Fix delegate mouseover check

### DIFF
--- a/gui/widgets/keep_toggle_delegate.py
+++ b/gui/widgets/keep_toggle_delegate.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import QStyledItemDelegate
+from PySide6.QtWidgets import QStyledItemDelegate, QStyle
 from PySide6.QtGui import QColor
 from PySide6.QtCore import Qt, QEvent
 
@@ -14,7 +14,7 @@ class KeepToggleDelegate(QStyledItemDelegate):
 
     def paint(self, painter, option, index):
         state = index.data(Qt.CheckStateRole)
-        if option.state & option.State_MouseOver:
+        if option.state & QStyle.State_MouseOver:
             color = self.hover_color
         elif state == Qt.Checked:
             color = self.checked_color


### PR DESCRIPTION
## Summary
- fix attr error in KeepToggleDelegate by using QStyle.State_MouseOver

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684310d4ea5483238a226d8722051ae3