### PR TITLE
Improve keep column interaction

### DIFF
--- a/gui/table_logic.py
+++ b/gui/table_logic.py
@@ -7,8 +7,7 @@ class TableLogic:
 
     def _on_table_clicked(self, index):
         if index.column() == 0:
-            t = self.track_table.table_model.track_at_row(index.row())
-            t.removed = not t.removed
+            # Delegate handles toggling, just refresh selection state
             self.track_table.table_model.dataChanged.emit(index, index, [Qt.CheckStateRole])
         self._on_selection_change(self.track_table.currentIndex(), None)
 

--- a/gui/widgets/keep_toggle_delegate.py
+++ b/gui/widgets/keep_toggle_delegate.py
@@ -4,7 +4,7 @@ from PySide6.QtCore import Qt, QEvent
 
 
 class KeepToggleDelegate(QStyledItemDelegate):
-    """Delegate that paints a full cell toggle for keeping/removing tracks."""
+    """Delegate that paints a button-like toggle for keeping/removing tracks."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -13,6 +13,7 @@ class KeepToggleDelegate(QStyledItemDelegate):
         self.hover_color = QColor("#51a4fc")
 
     def paint(self, painter, option, index):
+        painter.save()
         state = index.data(Qt.CheckStateRole)
         if option.state & QStyle.State_MouseOver:
             color = self.hover_color
@@ -21,6 +22,10 @@ class KeepToggleDelegate(QStyledItemDelegate):
         else:
             color = self.unchecked_color
         painter.fillRect(option.rect, color)
+        painter.setPen(Qt.white)
+        text = "Keep" if state == Qt.Checked else "Skip"
+        painter.drawText(option.rect, Qt.AlignCenter, text)
+        painter.restore()
 
     def editorEvent(self, event, model, option, index):
         if event.type() == QEvent.MouseButtonRelease and option.rect.contains(event.pos()):

--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -10,4 +10,5 @@ class TrackTable(QTableView):
         self.setModel(self.table_model)
         self.horizontalHeader().setDefaultAlignment(Qt.AlignCenter)
         self.setItemDelegateForColumn(0, KeepToggleDelegate(self))
+        self.setMouseTracking(True)
 


### PR DESCRIPTION
## Summary
- make the keep column visually behave like a toggle button
- enable mouse tracking on the table so the hover state works
- rely on the delegate for toggling logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843128186548323bb18639f2d8255bc