### PR TITLE
Move process buttons to top

### DIFF
--- a/gui/actions_logic.py
+++ b/gui/actions_logic.py
@@ -22,8 +22,13 @@ class ActionsLogic:
             self.action_bar.btn_preview.clicked.connect(self.preview_subtitle)
         if hasattr(self, "action_bar") and hasattr(self.action_bar, "btn_process_group"):
             self.action_bar.btn_process_group.clicked.connect(self.process_group)
+        elif hasattr(self, "group_bar") and hasattr(self.group_bar, "btn_process_group"):
+            self.group_bar.btn_process_group.clicked.connect(self.process_group)
+
         if hasattr(self, "action_bar") and hasattr(self.action_bar, "btn_process_all"):
             self.action_bar.btn_process_all.clicked.connect(self.process_all)
+        elif hasattr(self, "group_bar") and hasattr(self.group_bar, "btn_process_all"):
+            self.group_bar.btn_process_all.clicked.connect(self.process_all)
 
     def set_default_audio(self):
         row = self._current_idx()

--- a/gui/widgets/action_bar.py
+++ b/gui/widgets/action_bar.py
@@ -36,13 +36,6 @@ class ActionBar(QWidget):
         self.btn_preview = QPushButton("👁️ Preview Subtitle")
         self.btn_preview.setToolTip("Quickly check the subtitles before processing.")
 
-        self.btn_process_group = QPushButton("📦 Process Group")
-        self.btn_process_group.setToolTip(
-            "Apply cleaning to the current group only."
-        )
-
-        self.btn_process_all = QPushButton("🚀 Process All")
-        self.btn_process_all.setToolTip("Clean all loaded groups of videos.")
 
         for btn in (
             self.btn_open_files,
@@ -51,8 +44,6 @@ class ActionBar(QWidget):
             self.btn_forced,
             self.btn_wipe_all,
             self.btn_preview,
-            self.btn_process_group,
-            self.btn_process_all,
         ):
             btn.setMinimumHeight(38)
             btn.setMinimumWidth(110)

--- a/gui/widgets/group_bar.py
+++ b/gui/widgets/group_bar.py
@@ -36,6 +36,23 @@ class GroupBar(QWidget):
         self.group_btns_anchor = self.layout.count()
         self.stretch = self.layout.addStretch(1)
 
+        self.btn_process_group = QPushButton("📦 Process Group")
+        self.btn_process_group.setToolTip(
+            "Apply cleaning to the current group only."
+        )
+
+        self.btn_process_all = QPushButton("🚀 Process All")
+        self.btn_process_all.setToolTip("Clean all loaded groups of videos.")
+
+        for btn in (self.btn_process_group, self.btn_process_all):
+            btn.setMinimumHeight(38)
+            btn.setMinimumWidth(110)
+            btn.setStyleSheet(
+                "QPushButton { font-weight: 500; font-size: 14px;" +
+                " border-radius: 8px; padding: 5px 10px; }"
+            )
+            self.layout.addWidget(btn, alignment=Qt.AlignRight)
+
         self.backend_combo = QComboBox(self)
         self.backend_combo.addItems(["mkvtoolnix", "ffmpeg"])
         self.backend_combo.setCurrentText(DEFAULTS.get("backend", "ffmpeg"))


### PR DESCRIPTION
## Summary
- place `Process Group` and `Process All` buttons in the group bar
- remove process buttons from the action bar
- connect new group bar buttons to existing logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843143a31f083239157d93a569eee5c