### PR TITLE
Fix French flag support

### DIFF
--- a/core/flags.py
+++ b/core/flags.py
@@ -14,6 +14,7 @@ _LANG_TO_COUNTRY = {
     # French
     "fr": "FR",
     "fra": "FR",
+    "fre": "FR",
     # Italian
     "it": "IT",
     "ita": "IT",

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -3,6 +3,7 @@ from core.flags import lang_to_flag
 
 def test_lang_to_flag_known_codes():
     assert lang_to_flag('eng') == lang_to_flag('en') == '🇬🇧'
+    assert lang_to_flag('fra') == lang_to_flag('fre') == lang_to_flag('fr') == '🇫🇷'
     assert lang_to_flag('spa') == '🇪🇸'
     assert lang_to_flag('deu') == '🇩🇪'
     assert lang_to_flag('fas') == lang_to_flag('fa') == '🇮🇷'


### PR DESCRIPTION
## Summary
- include ISO code `fre` for French in language-to-flag map
- ensure French flag is tested

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431698de4083239375e64ac4a57a2c