### PR TITLE
Fix track table column stretch

### DIFF
--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -9,6 +9,7 @@ class TrackTable(QTableView):
         self.table_model = TrackTableModel()
         self.setModel(self.table_model)
         self.horizontalHeader().setDefaultAlignment(Qt.AlignCenter)
+        self.horizontalHeader().setStretchLastSection(True)
         self.setItemDelegateForColumn(0, KeepToggleDelegate(self))
         self.setMouseTracking(True)
         # Adjust row spacing whenever the model resets


### PR DESCRIPTION
## Summary
- keep the main window from expanding past the last column by stretching the last table column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431838c3188323b6a4152588ac4211