### PR TITLE
Add separate font size settings

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -36,7 +36,8 @@ DEFAULTS: Dict[str, Any] = {
     "ffprobe_cmd": FFPROBE,
     "output_dir": "cleaned",
     "max_workers": 4,
-    "font_size": 16,
+    "track_font_size": 16,
+    "preview_font_size": 16,
 }
 
 LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -1,6 +1,14 @@
 from PySide6.QtWidgets import (
-    QDialog, QFormLayout, QLineEdit, QCheckBox, QFileDialog,
-    QDialogButtonBox, QPushButton, QWidget, QHBoxLayout, QComboBox, QSpinBox
+    QDialog,
+    QFormLayout,
+    QLineEdit,
+    QCheckBox,
+    QFileDialog,
+    QDialogButtonBox,
+    QPushButton,
+    QWidget,
+    QHBoxLayout,
+    QComboBox,
 )
 from PySide6.QtCore import QSettings
 
@@ -49,10 +57,20 @@ class PreferencesDialog(QDialog):
         self.wipe_all_def.setChecked(self.settings.value("wipe_all_default", False, type=bool))
         layout.addRow("Wipe all subtitles by default:", self.wipe_all_def)
 
-        self.font_size_spin = QSpinBox(self)
-        self.font_size_spin.setRange(8, 72)
-        self.font_size_spin.setValue(int(self.settings.value("font_size", 16)))
-        layout.addRow("Track/preview font size:", self.font_size_spin)
+        sizes = [str(s) for s in range(10, 62, 2)]
+        self.track_font_combo = QComboBox(self)
+        self.track_font_combo.addItems(sizes)
+        self.track_font_combo.setCurrentText(
+            str(self.settings.value("track_font_size", 16))
+        )
+        layout.addRow("Track list font size:", self.track_font_combo)
+
+        self.preview_font_combo = QComboBox(self)
+        self.preview_font_combo.addItems(sizes)
+        self.preview_font_combo.setCurrentText(
+            str(self.settings.value("preview_font_size", 16))
+        )
+        layout.addRow("Subtitle preview font size:", self.preview_font_combo)
 
         self.buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, parent=self)
         self.buttons.accepted.connect(self.accept)
@@ -80,5 +98,8 @@ class PreferencesDialog(QDialog):
         self.settings.setValue("ffprobe_cmd", self.ffprobe_path.text())
         self.settings.setValue("output_dir", self.output_dir.text())
         self.settings.setValue("wipe_all_default", self.wipe_all_def.isChecked())
-        self.settings.setValue("font_size", max(8, self.font_size_spin.value()))
+        self.settings.setValue("track_font_size", int(self.track_font_combo.currentText()))
+        self.settings.setValue(
+            "preview_font_size", int(self.preview_font_combo.currentText())
+        )
         super().accept()

--- a/gui/settings_logic.py
+++ b/gui/settings_logic.py
@@ -25,13 +25,20 @@ class SettingsLogic:
         prefs["mkvextract_cmd"] = self.settings.value("mkvextract_cmd", prefs["mkvextract_cmd"])
         prefs["ffmpeg_cmd"]     = self.settings.value("ffmpeg_cmd", prefs["ffmpeg_cmd"])
         prefs["ffprobe_cmd"]    = self.settings.value("ffprobe_cmd", prefs["ffprobe_cmd"])
-        prefs["output_dir"]     = self.settings.value("output_dir", prefs["output_dir"])
-        prefs["font_size"]      = int(self.settings.value("font_size", prefs.get("font_size", 16)))
-        if prefs["font_size"] < 8:
-            prefs["font_size"] = 8
+        prefs["output_dir"]      = self.settings.value("output_dir", prefs["output_dir"])
+        prefs["track_font_size"] = int(
+            self.settings.value("track_font_size", prefs.get("track_font_size", 16))
+        )
+        if prefs["track_font_size"] < 10:
+            prefs["track_font_size"] = 10
+        prefs["preview_font_size"] = int(
+            self.settings.value("preview_font_size", prefs.get("preview_font_size", 16))
+        )
+        if prefs["preview_font_size"] < 10:
+            prefs["preview_font_size"] = 10
         DEFAULTS.update(prefs)
         if hasattr(self, "track_table"):
-            size = DEFAULTS.get("font_size", 16)
+            size = DEFAULTS.get("track_font_size", 16)
             self.track_table.setStyleSheet(f"font-size: {size}px;")
             self.track_table.horizontalHeader().setStyleSheet(
                 f"font-size: {size}px; font-weight: bold;"

--- a/gui/subtitle_preview.py
+++ b/gui/subtitle_preview.py
@@ -167,9 +167,9 @@ class SubtitlePreviewWindow(QMainWindow):
         self.extract_cmd = extract_cmd
         self.backend = backend
         self.settings = QSettings("MKVToolsCorp", "MKVCleaner")
-        self.font_size = int(self.settings.value("font_size", 16))
-        if self.font_size < 8:
-            self.font_size = 8
+        self.font_size = int(self.settings.value("preview_font_size", 16))
+        if self.font_size < 10:
+            self.font_size = 10
         self.pos = 0
 
         self.txt = QTextEdit(readOnly=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,7 +17,8 @@ def test_load_config_json(tmp_path):
     assert cfg["output_dir"] == "here"
     # ensure default populated
     assert cfg["mkvmerge_cmd"] == DEFAULTS["mkvmerge_cmd"]
-    assert cfg["font_size"] == DEFAULTS["font_size"]
+    assert cfg["track_font_size"] == DEFAULTS["track_font_size"]
+    assert cfg["preview_font_size"] == DEFAULTS["preview_font_size"]
 
 
 def test_load_config_toml(tmp_path):
@@ -29,4 +30,5 @@ def test_load_config_toml(tmp_path):
     assert cfg["max_workers"] == 8
     # unchanged value
     assert cfg["output_dir"] == DEFAULTS["output_dir"]
-    assert cfg["font_size"] == DEFAULTS["font_size"]
+    assert cfg["track_font_size"] == DEFAULTS["track_font_size"]
+    assert cfg["preview_font_size"] == DEFAULTS["preview_font_size"]


### PR DESCRIPTION
## Summary
- add `track_font_size` and `preview_font_size` settings
- replace font size spin box with dropdowns for track list and subtitle preview
- apply separate settings when loading preferences and displaying subtitles
- update tests for new defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432352bfd883238b22f5743c71ddf0