### PR TITLE
Improve table columns and language display

### DIFF
--- a/gui/models.py
+++ b/gui/models.py
@@ -28,15 +28,17 @@ class TrackTableModel(QAbstractTableModel):
         if role == Qt.CheckStateRole and c == 0:
             return Qt.Checked if not getattr(t, "removed", False) else Qt.Unchecked
         if role == Qt.DisplayRole:
+            lang_code = getattr(t, "language", "")
+            if t.type in {"audio", "subtitles"}:
+                flag = lang_to_flag(lang_code)
+                display_lang = f"{flag} {lang_code}" if flag else lang_code
+            else:
+                display_lang = lang_code
             return {
                 1: getattr(t, "tid", ""),
                 2: getattr(t, "type", ""),
                 3: getattr(t, "codec", ""),
-                4: (
-                    lang_to_flag(getattr(t, "language", ""))
-                    if t.type in {"audio", "subtitles"}
-                    else getattr(t, "language", "")
-                ),
+                4: display_lang,
                 5: "🚩" if getattr(t, "forced", False) else "",
                 6: (
                     "🔊"

--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -12,11 +12,10 @@ class TrackTable(QTableView):
         header = self.horizontalHeader()
         header.setDefaultAlignment(Qt.AlignCenter)
         # ensure the table width matches the column widths
-        header.setStretchLastSection(False)
+        # Let the columns automatically resize to fit their contents and
+        # use any remaining space for the last column.
+        header.setStretchLastSection(True)
         header.setSectionResizeMode(QHeaderView.ResizeToContents)
-        # match the name column width with the rest
-        header.setSectionResizeMode(7, QHeaderView.Fixed)
-        self.setColumnWidth(7, header.defaultSectionSize())
         self.resizeColumnsToContents()
         self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContents)
         self.setItemDelegateForColumn(0, KeepToggleDelegate(self))


### PR DESCRIPTION
## Summary
- let the track table stretch the last column instead of fixing width
- show the track language code next to its flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684325e0a29c8323a6bd376b65847f45