### PR TITLE
Implement content-based column sizing

### DIFF
--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -1,6 +1,7 @@
 
 from PySide6.QtWidgets import QTableView, QHeaderView, QAbstractScrollArea
 from PySide6.QtCore import Qt
+from PySide6.QtGui import QFontMetrics
 from gui.models import TrackTableModel
 from .keep_toggle_delegate import KeepToggleDelegate
 
@@ -11,17 +12,17 @@ class TrackTable(QTableView):
         self.setModel(self.table_model)
         header = self.horizontalHeader()
         header.setDefaultAlignment(Qt.AlignCenter)
-        # ensure the table width matches the column widths
-        # Let the columns automatically resize to fit their contents and
-        # use any remaining space for the last column.
-        header.setStretchLastSection(True)
-        header.setSectionResizeMode(QHeaderView.ResizeToContents)
-        self.resizeColumnsToContents()
+        header.setStretchLastSection(False)
+        header.setSectionResizeMode(QHeaderView.Fixed)
         self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContents)
         self.setItemDelegateForColumn(0, KeepToggleDelegate(self))
         self.setMouseTracking(True)
         # Adjust row spacing whenever the model resets
         self.table_model.modelReset.connect(self._apply_row_spacing)
+        # Update column widths whenever the model resets
+        self.table_model.modelReset.connect(self.adjust_column_widths)
+        # Initial width distribution
+        self.adjust_column_widths()
 
     def _apply_row_spacing(self):
         """Increase spacing between different track types."""
@@ -34,4 +35,29 @@ class TrackTable(QTableView):
                 height += 10
             self.setRowHeight(row, height)
             prev_type = track.type
+
+    def adjust_column_widths(self):
+        """Distribute available width between columns based on average content size."""
+        fm = QFontMetrics(self.font())
+        cols = self.table_model.columnCount()
+        rows = self.table_model.rowCount()
+        averages = []
+        for c in range(cols):
+            total = fm.horizontalAdvance(str(self.table_model.headerData(c, Qt.Horizontal)))
+            for r in range(rows):
+                idx = self.table_model.index(r, c)
+                data = self.table_model.data(idx, Qt.DisplayRole) or ""
+                total += fm.horizontalAdvance(str(data))
+            averages.append(total / max(rows + 1, 1))
+        total_avg = sum(averages)
+        if not total_avg:
+            return
+        width = self.viewport().width()
+        for c, avg in enumerate(averages):
+            w = int(width * avg / total_avg)
+            self.setColumnWidth(c, w)
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self.adjust_column_widths()
 


### PR DESCRIPTION
## Summary
- size table columns according to average content width
- recompute column widths when model resets or on resize

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68432729da9c832391aa0a7d95b80065