### PR TITLE
Hide vertical header in track table

### DIFF
--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -13,6 +13,8 @@ class TrackTable(QTableView):
         header.setDefaultAlignment(Qt.AlignCenter)
         header.setStretchLastSection(False)
         header.setSectionResizeMode(QHeaderView.Fixed)
+        # Hide vertical header that shows row numbers
+        self.verticalHeader().setVisible(False)
         self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContents)
         self.setItemDelegateForColumn(0, KeepToggleDelegate(self))
         self.setMouseTracking(True)


### PR DESCRIPTION
## Summary
- hide the table's vertical header so only the Keep column shows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432f89ce3c8323ae3d0bd00d0bebcf