### PR TITLE
Fix list stability and show file tooltips

### DIFF
--- a/gui/widgets/file_list.py
+++ b/gui/widgets/file_list.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import QListWidget
+from PySide6.QtWidgets import QListWidget, QListWidgetItem, QListView
 from PySide6.QtCore import Qt
 
 
@@ -12,18 +12,41 @@ class FileList(QListWidget):
         self.setFocusPolicy(Qt.NoFocus)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        # Arrange items in multiple columns
+        self.setFlow(QListView.LeftToRight)
+        self.setWrapping(True)
+        self.setResizeMode(QListView.Adjust)
+        self.setUniformItemSizes(True)
 
     def update_files(self, files):
         """Replace the list contents and resize to fit all rows."""
         self.clear()
         for p in files:
-            self.addItem(str(p.name))
+            item = QListWidgetItem(p.stem)
+            # Show full filename in a larger font inside the tooltip
+            item.setToolTip(f"<span style='font-size:16px'>{p.name}</span>")
+            self.addItem(item)
+
+        self._update_height()
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._update_height()
+
+    def _update_height(self):
+        import math
 
         rows = self.count()
-        if rows:
-            row_h = self.sizeHintForRow(0)
-            height = row_h * rows + 2 * self.frameWidth()
-        else:
+        if rows == 0:
             height = self.sizeHintForRow(0) + 2 * self.frameWidth()
+            self.setFixedHeight(height)
+            return
+
+        idx = self.model().index(0, 0)
+        item_w = self.sizeHintForIndex(idx).width()
+        item_h = self.sizeHintForIndex(idx).height()
+        cols = max(1, self.viewport().width() // max(1, item_w))
+        row_count = math.ceil(rows / cols)
+        height = item_h * row_count + 2 * self.frameWidth()
         self.setFixedHeight(height)
 

--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -16,6 +16,9 @@ class TrackTable(QTableView):
         # Hide vertical header that shows row numbers
         self.verticalHeader().setVisible(False)
         self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContents)
+        # Prevent flickering scrollbars when resizing
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setItemDelegateForColumn(0, KeepToggleDelegate(self))
         self.setMouseTracking(True)
         # Adjust row spacing whenever the model resets


### PR DESCRIPTION
## Summary
- disable scrollbars in the track table so they don't appear and disappear
- improve file list display: multi-column layout, show stems only
- add larger filename tooltip for each file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684342c21b5c8323935f2e29543fcd79