### PR TITLE
Improve default/forced status messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ are distributed alongside the bundle.
    ```
 3. Click **Open Files** to select one or more MKV files.
 4. For each group of files with the same track layout you can:
-   - uncheck tracks you wish to remove
-   - set a default audio or subtitle track
-   - toggle the forced subtitle flag
-   - preview subtitle text
-   - wipe all subtitles if desired
+    - uncheck tracks you wish to remove
+    - set a default audio or subtitle track
+    - toggle the forced subtitle flag
+    - preview subtitle text
+    - wipe all subtitles if desired
+    - the status bar shows which track became default or forced
 5. Use **Process Group** or **Process All** to create cleaned files in the output directory (by default `cleaned/`).
 
 Paths to the command line tools, the output directory and the preferred backend (MKVToolNix or FFmpeg) can be configured via the Preferences dialog (⚙️ icon).

--- a/gui/actions_logic.py
+++ b/gui/actions_logic.py
@@ -43,7 +43,10 @@ class ActionsLogic:
         t.default_audio = True
         self.track_table.table_model.update_tracks(self.track_table.table_model.tracks)
         if hasattr(self, "status_bar"):
-            self.status_bar.showMessage("Default audio set", 2000)
+            msg = f"Default audio set to track {t.tid} ({t.language})"
+            if t.name:
+                msg += f" - {t.name}"
+            self.status_bar.showMessage(msg, 2000)
 
     def set_default_subtitle(self):
         row = self._current_idx()
@@ -58,7 +61,10 @@ class ActionsLogic:
         t.default_subtitle = True
         self.track_table.table_model.update_tracks(self.track_table.table_model.tracks)
         if hasattr(self, "status_bar"):
-            self.status_bar.showMessage("Default subtitle set", 2000)
+            msg = f"Default subtitle set to track {t.tid} ({t.language})"
+            if t.name:
+                msg += f" - {t.name}"
+            self.status_bar.showMessage(msg, 2000)
 
     def set_forced_subtitle(self):
         row = self._current_idx()
@@ -70,7 +76,11 @@ class ActionsLogic:
         t.forced = not t.forced
         self.track_table.table_model.update_tracks(self.track_table.table_model.tracks)
         if hasattr(self, "status_bar"):
-            self.status_bar.showMessage("Forced flag toggled", 2000)
+            state = "enabled" if t.forced else "disabled"
+            msg = f"Forced flag {state} on track {t.tid} ({t.language})"
+            if t.name:
+                msg += f" - {t.name}"
+            self.status_bar.showMessage(msg, 2000)
 
     def wipe_all_subs(self):
         changed = False


### PR DESCRIPTION
## Summary
- show track details when setting default audio, default subtitle or toggling the forced flag
- mention status bar feedback in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843490a94f48323b30aa2dba4b74443