### PR TITLE
Track original flags in model

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ MKV Cleaner is an easy-to-use GUI for tidying Matroska (`.mkv`) files. You can q
 - **Batch processing** – clean groups of files with the same track layout all at once
 - **Drop unneeded tracks** – remove audio or subtitle tracks you don't want
 - **Control default and forced flags** for audio and subtitle tracks
+- *Faded flag icons show the original default/forced state from the file*
 - **Subtitle preview** lets you inspect text before processing
 - **Flexible backend** – work with either MKVToolNix or FFmpeg (FFmpeg is the default)
 - **Self-contained bundles** ship with all required dependencies

--- a/core/tracks.py
+++ b/core/tracks.py
@@ -22,6 +22,9 @@ class Track:
     default_audio: bool = False
     default_subtitle: bool = False
     removed: bool = False
+    orig_forced: bool = False
+    orig_default_audio: bool = False
+    orig_default_subtitle: bool = False
 
     def signature(self) -> str:
         return (
@@ -64,6 +67,8 @@ def query_tracks(source: Path) -> List[Track]:
         for i, t in enumerate(data.get("streams", [])):
             tags = t.get("tags", {})
             disp = t.get("disposition", {})
+            forced = bool(disp.get("forced", 0))
+            def_flag = bool(disp.get("default", 0))
             tracks.append(
                 Track(
                     idx=i,
@@ -71,10 +76,13 @@ def query_tracks(source: Path) -> List[Track]:
                     type="subtitles" if t.get("codec_type") == "subtitle" else t.get("codec_type", ""),
                     codec=t.get("codec_name", ""),
                     language=tags.get("language", "und"),
-                    forced=bool(disp.get("forced", 0)),
+                    forced=forced,
                     name=tags.get("title", ""),
-                    default_audio=bool(disp.get("default", 0)) if t.get("codec_type") == "audio" else False,
-                    default_subtitle=bool(disp.get("default", 0)) if t.get("codec_type") == "subtitle" else False,
+                    default_audio=def_flag if t.get("codec_type") == "audio" else False,
+                    default_subtitle=def_flag if t.get("codec_type") == "subtitle" else False,
+                    orig_forced=forced,
+                    orig_default_audio=def_flag if t.get("codec_type") == "audio" else False,
+                    orig_default_subtitle=def_flag if t.get("codec_type") == "subtitle" else False,
                 )
             )
         return tracks
@@ -84,6 +92,8 @@ def query_tracks(source: Path) -> List[Track]:
         tracks: List[Track] = []
         for i, t in enumerate(data.get("tracks", [])):
             p = t.get("properties", {})
+            forced = p.get("forced_track", False)
+            def_flag = p.get("default_track", False)
             tracks.append(
                 Track(
                     idx=i,
@@ -91,10 +101,13 @@ def query_tracks(source: Path) -> List[Track]:
                     type=t.get("type", ""),
                     codec=p.get("codec_id", ""),
                     language=p.get("language", "und"),
-                    forced=p.get("forced_track", False),
+                    forced=forced,
                     name=p.get("track_name", ""),
-                    default_audio=p.get("default_track", False) if t.get("type") == "audio" else False,
-                    default_subtitle=p.get("default_track", False) if t.get("type") == "subtitles" else False,
+                    default_audio=def_flag if t.get("type") == "audio" else False,
+                    default_subtitle=def_flag if t.get("type") == "subtitles" else False,
+                    orig_forced=forced,
+                    orig_default_audio=def_flag if t.get("type") == "audio" else False,
+                    orig_default_subtitle=def_flag if t.get("type") == "subtitles" else False,
                 )
             )
         return tracks

--- a/gui/models.py
+++ b/gui/models.py
@@ -5,6 +5,11 @@ from core.flags import lang_to_flag
 
 
 class TrackTableModel(QAbstractTableModel):
+    ForcedRole = Qt.UserRole + 1
+    OrigForcedRole = Qt.UserRole + 2
+    DefaultRole = Qt.UserRole + 3
+    OrigDefaultRole = Qt.UserRole + 4
+
     def __init__(self, tracks: list[Track] | None = None):
         super().__init__()
         self.tracks: list[Track] = tracks or []
@@ -32,6 +37,14 @@ class TrackTableModel(QAbstractTableModel):
             return Qt.AlignCenter
         if role == Qt.CheckStateRole and c == 0:
             return Qt.Checked if not getattr(t, "removed", False) else Qt.Unchecked
+        if role == self.ForcedRole:
+            return getattr(t, "forced", False)
+        if role == self.OrigForcedRole:
+            return getattr(t, "orig_forced", False)
+        if role == self.DefaultRole:
+            return getattr(t, "default_audio", False) if t.type == "audio" else getattr(t, "default_subtitle", False)
+        if role == self.OrigDefaultRole:
+            return getattr(t, "orig_default_audio", False) if t.type == "audio" else getattr(t, "orig_default_subtitle", False)
         if role == Qt.BackgroundRole:
             if getattr(t, "removed", False):
                 return self._remove_tint

--- a/gui/widgets/flag_delegate.py
+++ b/gui/widgets/flag_delegate.py
@@ -1,0 +1,42 @@
+from PySide6.QtWidgets import QStyledItemDelegate
+from PySide6.QtGui import QColor
+from PySide6.QtCore import Qt, QRect
+
+class FlagDelegate(QStyledItemDelegate):
+    """Paint current and original flag icons side by side."""
+
+    def __init__(self, column: int, parent=None):
+        super().__init__(parent)
+        self.column = column
+
+    def paint(self, painter, option, index):
+        model = index.model()
+        track = model.track_at_row(index.row())
+        if self.column == 5:
+            char = "🚩"
+            cur = bool(index.data(model.ForcedRole))
+            orig = bool(index.data(model.OrigForcedRole))
+        else:
+            char = "🔊" if track.type == "audio" else "CC"
+            cur = bool(index.data(model.DefaultRole))
+            orig = bool(index.data(model.OrigDefaultRole))
+        painter.save()
+        rect = option.rect
+        color = option.palette.text().color()
+        faded = QColor(color)
+        faded.setAlpha(100)
+        if cur and orig:
+            half = rect.width() // 2
+            orig_rect = QRect(rect.left(), rect.top(), half, rect.height())
+            cur_rect = QRect(rect.left() + half, rect.top(), rect.width() - half, rect.height())
+            painter.setPen(faded)
+            painter.drawText(orig_rect, Qt.AlignCenter, char)
+            painter.setPen(color)
+            painter.drawText(cur_rect, Qt.AlignCenter, char)
+        elif orig and not cur:
+            painter.setPen(faded)
+            painter.drawText(rect, Qt.AlignCenter, char)
+        elif cur:
+            painter.setPen(color)
+            painter.drawText(rect, Qt.AlignCenter, char)
+        painter.restore()

--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -3,6 +3,7 @@ from PySide6.QtWidgets import QTableView, QHeaderView, QAbstractScrollArea
 from PySide6.QtCore import Qt
 from gui.models import TrackTableModel
 from .keep_toggle_delegate import KeepToggleDelegate
+from .flag_delegate import FlagDelegate
 
 class TrackTable(QTableView):
     def __init__(self, parent=None):
@@ -20,6 +21,8 @@ class TrackTable(QTableView):
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setItemDelegateForColumn(0, KeepToggleDelegate(self))
+        self.setItemDelegateForColumn(5, FlagDelegate(5, self))
+        self.setItemDelegateForColumn(6, FlagDelegate(6, self))
         self.setMouseTracking(True)
         # Adjust row spacing whenever the model resets
         self.table_model.modelReset.connect(self._apply_row_spacing)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,6 +10,7 @@ qtcore.Qt = type('Qt', (), {
     'DisplayRole': 1,
     'TextAlignmentRole': 2,
     'AlignCenter': 4,
+    'UserRole': 8,
     'ItemIsEnabled': 1,
     'ItemIsSelectable': 2,
     'ItemIsUserCheckable': 4


### PR DESCRIPTION
## Summary
- remember original forced/default states when reading tracks
- expose these via custom table roles
- show faded icons for original values with new `FlagDelegate`
- note faded icons in README
- adjust Qt test shim for new roles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434d000e008323bfa469ab1babc885