### PR TITLE
Improve track table selection and coloring

### DIFF
--- a/gui/models.py
+++ b/gui/models.py
@@ -17,6 +17,13 @@ class TrackTableModel(QAbstractTableModel):
         self._change_tint.setAlpha(40)
         self._remove_tint = QColor("#c75f5f")
         self._remove_tint.setAlpha(40)
+        self._type_colors = {
+            "video": QColor("#4e9a06"),
+            "audio": QColor("#3465a4"),
+            "subtitles": QColor("#c17d11"),
+        }
+        for col in self._type_colors.values():
+            col.setAlpha(40)
 
     def rowCount(self, parent=QModelIndex()):
         return len(self.tracks)
@@ -48,6 +55,10 @@ class TrackTableModel(QAbstractTableModel):
         if role == Qt.BackgroundRole:
             if getattr(t, "removed", False):
                 return self._remove_tint
+            if c == 2:
+                col = self._type_colors.get(t.type)
+                if col:
+                    return col
             if c == 5 and getattr(t, "forced", False):
                 return self._change_tint
             if c == 6 and (

--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -1,5 +1,10 @@
 
-from PySide6.QtWidgets import QTableView, QHeaderView, QAbstractScrollArea
+from PySide6.QtWidgets import (
+    QTableView,
+    QHeaderView,
+    QAbstractScrollArea,
+    QAbstractItemView,
+)
 from PySide6.QtCore import Qt
 from gui.models import TrackTableModel
 from .keep_toggle_delegate import KeepToggleDelegate
@@ -10,6 +15,8 @@ class TrackTable(QTableView):
         super().__init__(parent)
         self.table_model = TrackTableModel()
         self.setModel(self.table_model)
+        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionMode(QAbstractItemView.SingleSelection)
         header = self.horizontalHeader()
         header.setDefaultAlignment(Qt.AlignCenter)
         header.setStretchLastSection(False)


### PR DESCRIPTION
## Summary
- highlight selected rows instead of single cells
- show different track-type colors in the Type column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68435be54abc8323b997c6682e756bdb