### PR TITLE
Fix fade effect on disabled action bar buttons

### DIFF
--- a/gui/widgets/fade_disabled.py
+++ b/gui/widgets/fade_disabled.py
@@ -1,21 +1,32 @@
 try:
     from PySide6.QtWidgets import QGraphicsOpacityEffect
+    from PySide6.QtCore import QObject, QEvent
 except Exception:  # PySide6 may be stubbed in tests
     QGraphicsOpacityEffect = None
+    QObject = object
+    QEvent = None
 
 
 def apply_fade_on_disable(widget, disabled_opacity=0.4):
     """Add an opacity effect that fades the widget when disabled."""
     if QGraphicsOpacityEffect is None:
         return
-    if not hasattr(widget, "setGraphicsEffect") or not hasattr(widget, "enabledChanged"):
+    if not hasattr(widget, "setGraphicsEffect") or not hasattr(widget, "installEventFilter"):
         return
 
     effect = QGraphicsOpacityEffect(widget)
     widget.setGraphicsEffect(effect)
     effect.setOpacity(1.0 if widget.isEnabled() else disabled_opacity)
 
-    def _update(enabled):
-        effect.setOpacity(1.0 if enabled else disabled_opacity)
+    class _FadeFilter(QObject):
+        def eventFilter(self, obj, event):
+            if obj is widget and QEvent is not None and event.type() == QEvent.EnabledChange:
+                effect.setOpacity(1.0 if widget.isEnabled() else disabled_opacity)
+            return False
 
-    widget.enabledChanged.connect(_update)
+    filt = _FadeFilter(widget)
+    widget.installEventFilter(filt)
+    # Keep reference to avoid garbage collection
+    if not hasattr(widget, "_fade_filters"):
+        widget._fade_filters = []
+    widget._fade_filters.append(filt)


### PR DESCRIPTION
## Summary
- ensure disabled buttons actually fade by listening for the `EnabledChange` event

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436156d2b08323b1ea638e71361248