### PR TITLE
Fade disabled subtitle preview buttons

### DIFF
--- a/gui/subtitle_preview.py
+++ b/gui/subtitle_preview.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import (
     QWidget,
     QPushButton,
 )
+from .widgets.fade_disabled import apply_fade_on_disable
 from PySide6.QtCore import QSettings
 from pathlib import Path
 import tempfile
@@ -176,7 +177,9 @@ class SubtitlePreviewWindow(QMainWindow):
         self.txt = QTextEdit(readOnly=True)
         nav = QHBoxLayout()
         self.prev = QPushButton("◀ Prev")
+        apply_fade_on_disable(self.prev)
         self.nxt = QPushButton("Next ▶")
+        apply_fade_on_disable(self.nxt)
         nav.addWidget(self.prev)
         nav.addStretch()
         nav.addWidget(self.nxt)


### PR DESCRIPTION
## Summary
- apply fade effect to subtitle preview navigation buttons
- use the same fading as other disabled buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843681164188323a2baf96ca7b8df9b