### PR TITLE
Remove vertical cell borders

### DIFF
--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -17,6 +17,8 @@ class TrackTable(QTableView):
         self.setModel(self.table_model)
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.setSelectionMode(QAbstractItemView.SingleSelection)
+        # Disable built-in grid lines, we'll draw horizontal lines via CSS
+        self.setShowGrid(False)
         header = self.horizontalHeader()
         header.setDefaultAlignment(Qt.AlignCenter)
         header.setStretchLastSection(False)

--- a/mkv_cleaner.py
+++ b/mkv_cleaner.py
@@ -49,12 +49,15 @@ def set_dynamic_modern_style(app: QApplication) -> None:
             font-size: 16px;
         }}
         QTableView::item {{
-            border-right: 1px solid #34394c;
+            border-right: none;
             border-bottom: 1px solid #34394c;
         }}
         QTableView::item:selected {{
-            /* highlight all cell borders when selected */
-            border: 1px solid {accent};
+            /* highlight row with accent color */
+            border-right: none;
+            border-left: none;
+            border-top: 1px solid {accent};
+            border-bottom: 1px solid {accent};
         }}
         QHeaderView::section {{
             background-color: #232a34;


### PR DESCRIPTION
## Summary
- stop vertical grid lines in the track table
- disable built‑in grid drawing and draw only horizontal borders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436a1f9d7c8323bb9757f651851b12