### PR TITLE
Fix table selection highlight

### DIFF
--- a/gui/widgets/flag_delegate.py
+++ b/gui/widgets/flag_delegate.py
@@ -22,6 +22,8 @@ class FlagDelegate(QStyledItemDelegate):
 
         opt = QStyleOptionViewItem(option)
         self.initStyleOption(opt, index)
+        # Remove focus state so cells don't show selection outlines
+        opt.state &= ~QStyle.State_HasFocus
 
         painter.save()
         style = opt.widget.style() if opt.widget else QApplication.style()

--- a/gui/widgets/keep_toggle_delegate.py
+++ b/gui/widgets/keep_toggle_delegate.py
@@ -15,6 +15,8 @@ class KeepToggleDelegate(QStyledItemDelegate):
     def paint(self, painter, option, index):
         opt = QStyleOptionViewItem(option)
         self.initStyleOption(opt, index)
+        # Remove focus state so no cell highlight outline is drawn
+        opt.state &= ~QStyle.State_HasFocus
 
         painter.save()
         style = opt.widget.style() if opt.widget else QApplication.style()

--- a/mkv_cleaner.py
+++ b/mkv_cleaner.py
@@ -43,7 +43,8 @@ def set_dynamic_modern_style(app: QApplication) -> None:
             alternate-background-color: #252b33;
             color: #d0e8f7;
             gridline-color: #34394c;
-            selection-background-color: {accent};
+            /* highlight rows via borders, not filled background */
+            selection-background-color: transparent;
             selection-color: #fff;
             font-family: 'Segoe UI', 'Noto Color Emoji';
             font-size: 16px;
@@ -58,6 +59,9 @@ def set_dynamic_modern_style(app: QApplication) -> None:
             border-left: none;
             border-top: 1px solid {accent};
             border-bottom: 1px solid {accent};
+        }}
+        QTableView::item:focus {{
+            outline: none;
         }}
         QHeaderView::section {{
             background-color: #232a34;


### PR DESCRIPTION
## Summary
- keep table selection from filling the cell background
- remove cell focus outline in custom delegates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68436b1601a083238e016b1b13a3b717