### PR TITLE
Remove cell focus highlight

### DIFF
--- a/gui/widgets/no_focus_delegate.py
+++ b/gui/widgets/no_focus_delegate.py
@@ -1,0 +1,11 @@
+from PySide6.QtWidgets import QStyledItemDelegate, QStyleOptionViewItem
+from PySide6.QtGui import QPainter
+from PySide6.QtCore import QStyle
+
+class NoFocusDelegate(QStyledItemDelegate):
+    """Delegate that removes the focus outline from table cells."""
+
+    def paint(self, painter: QPainter, option: QStyleOptionViewItem, index):
+        opt = QStyleOptionViewItem(option)
+        opt.state &= ~QStyle.State_HasFocus
+        super().paint(painter, opt, index)

--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -9,6 +9,7 @@ from PySide6.QtCore import Qt
 from gui.models import TrackTableModel
 from .keep_toggle_delegate import KeepToggleDelegate
 from .flag_delegate import FlagDelegate
+from .no_focus_delegate import NoFocusDelegate
 
 class TrackTable(QTableView):
     def __init__(self, parent=None):
@@ -29,6 +30,7 @@ class TrackTable(QTableView):
         # Prevent flickering scrollbars when resizing
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setItemDelegate(NoFocusDelegate(self))
         self.setItemDelegateForColumn(0, KeepToggleDelegate(self))
         self.setItemDelegateForColumn(5, FlagDelegate(5, self))
         self.setItemDelegateForColumn(6, FlagDelegate(6, self))


### PR DESCRIPTION
## Summary
- add `NoFocusDelegate` to remove focus highlight on table cells
- use `NoFocusDelegate` for uncustomized columns in track table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436c369b0c8323ae31740f75e734e0