### PR TITLE
Fix incorrect QStyle import

### DIFF
--- a/gui/widgets/no_focus_delegate.py
+++ b/gui/widgets/no_focus_delegate.py
@@ -1,6 +1,9 @@
-from PySide6.QtWidgets import QStyledItemDelegate, QStyleOptionViewItem
+from PySide6.QtWidgets import (
+    QStyledItemDelegate,
+    QStyleOptionViewItem,
+    QStyle,
+)
 from PySide6.QtGui import QPainter
-from PySide6.QtCore import QStyle
 
 class NoFocusDelegate(QStyledItemDelegate):
     """Delegate that removes the focus outline from table cells."""


### PR DESCRIPTION
## Summary
- import QStyle from `PySide6.QtWidgets` instead of `QtCore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436ce6781c8323a869782dfc20bba9