### PR TITLE
Include fonts directory in wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include fonts/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ mkv-cleaner = "mkv_cleaner:main"
 [tool.setuptools]
 py-modules = ["mkv_cleaner"]
 
+[tool.setuptools.data-files]
+"fonts" = ["fonts/*"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["core", "gui"]


### PR DESCRIPTION
## Summary
- include fonts directory when building packages
- add MANIFEST.in for fonts

## Testing
- `pytest -q`
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_68436f228b3c8323983a563c4cccc043