### PR TITLE
Add checksum validation for downloaded binaries

### DIFF
--- a/core/bootstrap.py
+++ b/core/bootstrap.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import tempfile
 import urllib.request
+import hashlib
 from pathlib import Path
 
 # Directory containing ``mkv_cleaner.py``
@@ -17,12 +18,14 @@ APP_DIR = Path(__file__).resolve().parents[1]
 SKIP_BOOTSTRAP = os.environ.get("MKVCLEANER_SKIP_BOOTSTRAP")
 
 
-def ensure_binary(exe_name: str, url: str) -> str:
+def ensure_binary(exe_name: str, url: str, checksum: str | None = None) -> str:
     """Ensure ``exe_name`` exists next to ``mkv_cleaner.py``.
 
     If the executable is missing it will be downloaded from ``url`` which is
-    expected to be an archive containing the program. The executable is
-    extracted and its local path is returned.
+    expected to be an archive containing the program. The optional ``checksum``
+    should be the SHA256 hex digest of the archive. If provided, the downloaded
+    archive is verified before unpacking and a :class:`ValueError` is raised on
+    mismatch. The executable is extracted and its local path is returned.
     """
     exe_path = APP_DIR / exe_name
     if SKIP_BOOTSTRAP:
@@ -34,6 +37,13 @@ def ensure_binary(exe_name: str, url: str) -> str:
         suffix = Path(url).suffix or '.zip'
         archive = Path(tmpdir) / f"download{suffix}"
         urllib.request.urlretrieve(url, archive)
+        if checksum is not None:
+            h = hashlib.sha256()
+            with open(archive, "rb") as fh:
+                for chunk in iter(lambda: fh.read(8192), b""):
+                    h.update(chunk)
+            if h.hexdigest().lower() != checksum.lower():
+                raise ValueError("Checksum mismatch")
         shutil.unpack_archive(str(archive), tmpdir)
 
         found = None

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -5,6 +5,8 @@ import sys
 import zipfile
 from pathlib import Path
 import importlib
+import hashlib
+import pytest
 
 import core.bootstrap as bootstrap
 
@@ -26,14 +28,40 @@ def test_ensure_binary_download(monkeypatch, tmp_path):
     monkeypatch.setattr(bootstrap, 'APP_DIR', tmp_path)
     monkeypatch.setattr(bootstrap.urllib.request, 'urlretrieve', fake_urlretrieve)
 
-    path = bootstrap.ensure_binary(exe, 'http://example/archive.zip')
+    checksum = hashlib.sha256(archive.read_bytes()).hexdigest()
+    path = bootstrap.ensure_binary(exe, 'http://example/archive.zip', checksum=checksum)
     assert Path(path) == tmp_path / exe
     assert (tmp_path / exe).exists()
     assert calls
 
     calls.clear()
-    bootstrap.ensure_binary(exe, 'http://example/archive.zip')
+    bootstrap.ensure_binary(exe, 'http://example/archive.zip', checksum=checksum)
     assert not calls
+
+
+def test_ensure_binary_bad_checksum(monkeypatch, tmp_path):
+    monkeypatch.delenv('MKVCLEANER_SKIP_BOOTSTRAP', raising=False)
+    monkeypatch.setattr(bootstrap, 'SKIP_BOOTSTRAP', None)
+    exe = 'tool.exe' if os.name == 'nt' else 'tool'
+    archive = tmp_path / 'a.zip'
+    with zipfile.ZipFile(archive, 'w') as z:
+        z.writestr(exe, 'x')
+
+    def fake_urlretrieve(url, filename):
+        shutil.copy(archive, filename)
+
+    called = {}
+
+    def fake_unpack(src, dst):
+        called['unpacked'] = True
+
+    monkeypatch.setattr(bootstrap, 'APP_DIR', tmp_path)
+    monkeypatch.setattr(bootstrap.urllib.request, 'urlretrieve', fake_urlretrieve)
+    monkeypatch.setattr(bootstrap.shutil, 'unpack_archive', fake_unpack)
+
+    with pytest.raises(ValueError):
+        bootstrap.ensure_binary(exe, 'http://example/archive.zip', checksum='0'*64)
+    assert 'unpacked' not in called
 
 
 def test_ensure_python_package(monkeypatch):


### PR DESCRIPTION
## Summary
- verify optional checksum in `ensure_binary`
- test checksum mismatch handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437410d4d88323855e149d536a3ca0