### PR TITLE
Improve flag mapping and locale fallback

### DIFF
--- a/core/flags.py
+++ b/core/flags.py
@@ -72,6 +72,49 @@ _LANG_TO_COUNTRY = {
     # Thai
     "th": "TH",
     "tha": "TH",
+    # Danish
+    "da": "DK",
+    "dan": "DK",
+    # Finnish
+    "fi": "FI",
+    "fin": "FI",
+    # Hungarian
+    "hu": "HU",
+    "hun": "HU",
+    # Norwegian
+    "no": "NO",
+    "nor": "NO",
+    # Romanian
+    "ro": "RO",
+    "ron": "RO",
+    "rum": "RO",
+    # Bulgarian
+    "bg": "BG",
+    "bul": "BG",
+    # Czech
+    "cs": "CZ",
+    "ces": "CZ",
+    "cze": "CZ",
+    # Slovak
+    "sk": "SK",
+    "slk": "SK",
+    "slo": "SK",
+    # Croatian
+    "hr": "HR",
+    "hrv": "HR",
+    # Ukrainian
+    "uk": "UA",
+    "ukr": "UA",
+    # Indonesian
+    "id": "ID",
+    "ind": "ID",
+    # Malay
+    "ms": "MY",
+    "msa": "MY",
+    "may": "MY",
+    # Filipino/Tagalog
+    "tl": "PH",
+    "tgl": "PH",
 }
 
 
@@ -88,6 +131,18 @@ def lang_to_flag(lang: str) -> str:
         return ""
     lang = lang.lower()
     cc = _LANG_TO_COUNTRY.get(lang)
-    if cc:
-        return _country_code_to_flag(cc)
-    return ""
+    if not cc:
+        if '-' in lang or '_' in lang:
+            country = lang.split('-')[1] if '-' in lang else lang.split('_')[1]
+            if len(country) == 2:
+                cc = country.upper()
+    if not cc:
+        import locale
+        loc = locale.getdefaultlocale()[0] or ''
+        if not loc:
+            loc = locale.getlocale()[0] or ''
+        if loc and ('_' in loc or '-' in loc):
+            country = loc.split('_')[1] if '_' in loc else loc.split('-')[1]
+            if len(country) == 2:
+                cc = country.upper()
+    return _country_code_to_flag(cc) if cc else ""

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -8,7 +8,22 @@ def test_lang_to_flag_known_codes():
     assert lang_to_flag('deu') == '🇩🇪'
     assert lang_to_flag('fas') == lang_to_flag('fa') == '🇮🇷'
     assert lang_to_flag('pol') == '🇵🇱'
+    assert lang_to_flag('dan') == lang_to_flag('da') == '🇩🇰'
+    assert lang_to_flag('ces') == lang_to_flag('cs') == '🇨🇿'
+    assert lang_to_flag('hrv') == lang_to_flag('hr') == '🇭🇷'
 
 
-def test_lang_to_flag_unknown():
+def test_lang_to_flag_unknown(monkeypatch):
+    import locale
+
+    monkeypatch.setattr(locale, 'getdefaultlocale', lambda: (None, None))
+    monkeypatch.setattr(locale, 'getlocale', lambda: (None, None))
     assert lang_to_flag('xxx') == ''
+
+
+def test_lang_to_flag_locale_fallback(monkeypatch):
+    import locale
+
+    monkeypatch.setattr(locale, 'getdefaultlocale', lambda: ('fr_FR', 'UTF-8'))
+    monkeypatch.setattr(locale, 'getlocale', lambda: ('fr_FR', 'UTF-8'))
+    assert lang_to_flag('xxx') == '🇫🇷'


### PR DESCRIPTION
## Summary
- expand `_LANG_TO_COUNTRY` with many new ISO language codes
- fall back to the system locale when mapping is missing
- test new codes and locale detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437418a45c8323b33abad53e4e8dfa