### PR TITLE
Add accent color preference

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -40,6 +40,7 @@ DEFAULTS: Dict[str, Any] = {
     "max_workers": 4,
     "track_font_size": 16,
     "preview_font_size": 16,
+    "accent_color": "",
 }
 
 LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -72,6 +72,11 @@ class PreferencesDialog(QDialog):
         )
         layout.addRow("Subtitle preview font size:", self.preview_font_combo)
 
+        self.accent_edit = QLineEdit(self)
+        self.accent_edit.setPlaceholderText("#RRGGBB or empty for random")
+        self.accent_edit.setText(self.settings.value("accent_color", ""))
+        layout.addRow("Accent color:", self.accent_edit)
+
         self.buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, parent=self)
         self.buttons.accepted.connect(self.accept)
         self.buttons.rejected.connect(self.reject)
@@ -102,4 +107,5 @@ class PreferencesDialog(QDialog):
         self.settings.setValue(
             "preview_font_size", int(self.preview_font_combo.currentText())
         )
+        self.settings.setValue("accent_color", self.accent_edit.text())
         super().accept()

--- a/gui/settings_logic.py
+++ b/gui/settings_logic.py
@@ -26,6 +26,7 @@ class SettingsLogic:
         prefs["ffmpeg_cmd"]     = self.settings.value("ffmpeg_cmd", prefs["ffmpeg_cmd"])
         prefs["ffprobe_cmd"]    = self.settings.value("ffprobe_cmd", prefs["ffprobe_cmd"])
         prefs["output_dir"]      = self.settings.value("output_dir", prefs["output_dir"])
+        prefs["accent_color"]    = self.settings.value("accent_color", prefs.get("accent_color", ""))
         prefs["track_font_size"] = int(
             self.settings.value("track_font_size", prefs.get("track_font_size", 16))
         )

--- a/mkv_cleaner.py
+++ b/mkv_cleaner.py
@@ -19,9 +19,10 @@ from gui.widgets.fast_tooltip_style import FastToolTipStyle
 from pathlib import Path
 from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QFont, QFontDatabase
+from PySide6.QtCore import QSettings
 
 def set_dynamic_modern_style(app: QApplication) -> None:
-    """Apply a dark theme with a random accent color to ``app``."""
+    """Apply a dark theme with an accent color to ``app``."""
     accents = [
         "#429aff",  # blue
         "#30d0c6",  # teal
@@ -30,7 +31,10 @@ def set_dynamic_modern_style(app: QApplication) -> None:
         "#6fc3df",  # light blue/teal
         "#ff79c6",  # pink/magenta
     ]
-    accent = random.choice(accents)
+    settings = QSettings("MKVToolsCorp", "MKVCleaner")
+    accent = settings.value("accent_color", "")
+    if not accent:
+        accent = random.choice(accents)
 
     app.setStyleSheet(f"""
         QMainWindow, QWidget {{


### PR DESCRIPTION
## Summary
- read an optional accent color preference in `SettingsLogic`
- add accent color field in `PreferencesDialog`
- respect stored accent color in `set_dynamic_modern_style`
- expose new default value in `config`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437411619c83239958e6b207dddf94