### PR TITLE
Introduce AppConfig dataclass

### DIFF
--- a/gui/actions_logic.py
+++ b/gui/actions_logic.py
@@ -1,7 +1,6 @@
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QMessageBox
 from core.tracks import query_tracks, build_cmd, run_command
-from core.config import DEFAULTS
 from .subtitle_preview import SubtitlePreviewWindow
 from .processing import process_files
 
@@ -117,8 +116,8 @@ class ActionsLogic:
             t.language,
             t.name,
             run_command,
-            DEFAULTS["ffmpeg_cmd"] if DEFAULTS.get("backend") == "ffmpeg" else DEFAULTS["mkvextract_cmd"],
-            DEFAULTS.get("backend", "ffmpeg"),
+            self.app_config.ffmpeg_cmd if self.app_config.backend == "ffmpeg" else self.app_config.mkvextract_cmd,
+            self.app_config.backend,
             parent=self,
         )
         self._preview_win.show()
@@ -135,11 +134,11 @@ class ActionsLogic:
         wipe = self.action_bar.btn_wipe_all.isChecked() or getattr(self, "wipe_all_default", False)
         process_files(
             jobs,
-            DEFAULTS["max_workers"],
-            query_tracks,
-            build_cmd,
+            self.app_config.max_workers,
+            lambda src: query_tracks(src, self.app_config),
+            lambda s, d, t, wipe_forced=False, wipe_all=False: build_cmd(s, d, t, self.app_config, wipe_forced, wipe_all),
             run_command,
-            DEFAULTS["output_dir"],
+            self.app_config.output_dir,
             wipe,
             parent=self,
         )
@@ -156,11 +155,11 @@ class ActionsLogic:
         wipe = self.action_bar.btn_wipe_all.isChecked() or getattr(self, "wipe_all_default", False)
         process_files(
             jobs,
-            DEFAULTS["max_workers"],
-            query_tracks,
-            build_cmd,
+            self.app_config.max_workers,
+            lambda src: query_tracks(src, self.app_config),
+            lambda s, d, t, wipe_forced=False, wipe_all=False: build_cmd(s, d, t, self.app_config, wipe_forced, wipe_all),
             run_command,
-            DEFAULTS["output_dir"],
+            self.app_config.output_dir,
             wipe,
             parent=self,
         )

--- a/gui/group_logic.py
+++ b/gui/group_logic.py
@@ -44,7 +44,7 @@ class GroupLogic:
 
     def add_files_to_groups(self, paths):
         for p in paths:
-            tracks = query_tracks(Path(p))
+            tracks = query_tracks(Path(p), self.app_config)
             sig = ";".join(t.signature() for t in tracks)
             if sig not in self.groups:
                 self.groups[sig] = [copy.deepcopy(t) for t in tracks]

--- a/gui/widgets/group_bar.py
+++ b/gui/widgets/group_bar.py
@@ -8,7 +8,6 @@ from PySide6.QtWidgets import (
     QComboBox,
 )
 from PySide6.QtCore import Qt, QSize, Signal
-from core.config import DEFAULTS
 
 from .fade_disabled import apply_fade_on_disable
 
@@ -91,7 +90,7 @@ class GroupBar(QWidget):
 
         self.backend_combo = QComboBox(self)
         self.backend_combo.addItems(["mkvtoolnix", "ffmpeg"])
-        self.backend_combo.setCurrentText(DEFAULTS.get("backend", "ffmpeg"))
+        self.backend_combo.setCurrentText("ffmpeg")
         self.backend_combo.setToolTip("Select backend")
         self.backend_combo.currentTextChanged.connect(self.backendChanged.emit)
         self.backend_combo.setFixedHeight(32)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import copy
 import os
 import sys
 from pathlib import Path
@@ -10,12 +9,9 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from core.config import DEFAULTS
+from core.config import AppConfig
 
 
 @pytest.fixture
 def defaults():
-    backup = copy.deepcopy(DEFAULTS)
-    yield DEFAULTS
-    DEFAULTS.clear()
-    DEFAULTS.update(backup)
+    return AppConfig()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -69,8 +69,8 @@ def test_config_uses_system_binaries(monkeypatch):
     importlib.reload(config)
     ext = '.exe' if os.name == 'nt' else ''
     assert config.MKVMERGE == f'mkvmerge{ext}'
-    assert config.DEFAULTS['mkvmerge_cmd'] == f'mkvmerge{ext}'
-    assert config.DEFAULTS['ffmpeg_cmd'] == f'ffmpeg{ext}'
+    assert config.AppConfig().mkvmerge_cmd == f'mkvmerge{ext}'
+    assert config.AppConfig().ffmpeg_cmd == f'ffmpeg{ext}'
     assert not called
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from core.config import load_config, DEFAULTS  # noqa: E402
+from core.config import load_config, AppConfig  # noqa: E402
 
 
 def test_load_config_json(tmp_path):
@@ -13,12 +13,13 @@ def test_load_config_json(tmp_path):
     conf_file.write_text(json.dumps({"backend": "ffmpeg", "output_dir": "here"}))
 
     cfg = load_config(conf_file)
-    assert cfg["backend"] == "ffmpeg"
-    assert cfg["output_dir"] == "here"
+    default = AppConfig()
+    assert cfg.backend == "ffmpeg"
+    assert cfg.output_dir == "here"
     # ensure default populated
-    assert cfg["mkvmerge_cmd"] == DEFAULTS["mkvmerge_cmd"]
-    assert cfg["track_font_size"] == DEFAULTS["track_font_size"]
-    assert cfg["preview_font_size"] == DEFAULTS["preview_font_size"]
+    assert cfg.mkvmerge_cmd == default.mkvmerge_cmd
+    assert cfg.track_font_size == default.track_font_size
+    assert cfg.preview_font_size == default.preview_font_size
 
 
 def test_load_config_toml(tmp_path):
@@ -26,9 +27,10 @@ def test_load_config_toml(tmp_path):
     conf_file.write_text("backend='ffmpeg'\nmax_workers=8")
 
     cfg = load_config(conf_file)
-    assert cfg["backend"] == "ffmpeg"
-    assert cfg["max_workers"] == 8
+    default = AppConfig()
+    assert cfg.backend == "ffmpeg"
+    assert cfg.max_workers == 8
     # unchanged value
-    assert cfg["output_dir"] == DEFAULTS["output_dir"]
-    assert cfg["track_font_size"] == DEFAULTS["track_font_size"]
-    assert cfg["preview_font_size"] == DEFAULTS["preview_font_size"]
+    assert cfg.output_dir == default.output_dir
+    assert cfg.track_font_size == default.track_font_size
+    assert cfg.preview_font_size == default.preview_font_size

--- a/tests/test_tracks.py
+++ b/tests/test_tracks.py
@@ -32,8 +32,8 @@ def test_build_cmd_flags(defaults):
             default_subtitle=True,
         ),
     ]
-    defaults["backend"] = "mkvtoolnix"
-    cmd = build_cmd(src, dst, tracks, wipe_forced=True, wipe_all=False)
+    defaults.backend = "mkvtoolnix"
+    cmd = build_cmd(src, dst, tracks, defaults, wipe_forced=True, wipe_all=False)
     assert cmd == [
         "mkvmerge",
         "--forced-track",
@@ -47,8 +47,8 @@ def test_build_cmd_flags(defaults):
         str(src),
     ]
 
-    defaults["backend"] = "ffmpeg"
-    cmd = build_cmd(src, dst, tracks, wipe_forced=True, wipe_all=False)
+    defaults.backend = "ffmpeg"
+    cmd = build_cmd(src, dst, tracks, defaults, wipe_forced=True, wipe_all=False)
     assert cmd == [
         "ffmpeg",
         "-loglevel",
@@ -92,8 +92,8 @@ def test_build_cmd_wipe_all(defaults):
             default_subtitle=True,
         ),
     ]
-    defaults["backend"] = "mkvtoolnix"
-    cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=True)
+    defaults.backend = "mkvtoolnix"
+    cmd = build_cmd(src, dst, tracks, defaults, wipe_forced=False, wipe_all=True)
     assert cmd == [
         "mkvmerge",
         "--no-subtitles",
@@ -108,8 +108,8 @@ def test_build_cmd_wipe_all(defaults):
         str(src),
     ]
 
-    defaults["backend"] = "ffmpeg"
-    cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=True)
+    defaults.backend = "ffmpeg"
+    cmd = build_cmd(src, dst, tracks, defaults, wipe_forced=False, wipe_all=True)
     assert cmd == [
         "ffmpeg",
         "-loglevel",
@@ -153,8 +153,8 @@ def test_build_cmd_forced_default_ffmpeg(defaults):
             default_subtitle=True,
         ),
     ]
-    defaults["backend"] = "mkvtoolnix"
-    cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=False)
+    defaults.backend = "mkvtoolnix"
+    cmd = build_cmd(src, dst, tracks, defaults, wipe_forced=False, wipe_all=False)
     assert cmd == [
         "mkvmerge",
         "--forced-track",
@@ -168,8 +168,8 @@ def test_build_cmd_forced_default_ffmpeg(defaults):
         str(src),
     ]
 
-    defaults["backend"] = "ffmpeg"
-    cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=False)
+    defaults.backend = "ffmpeg"
+    cmd = build_cmd(src, dst, tracks, defaults, wipe_forced=False, wipe_all=False)
     assert cmd == [
         "ffmpeg",
         "-loglevel",
@@ -231,8 +231,8 @@ def test_build_cmd_full_flags(defaults):
             default_subtitle=True,
         ),
     ]
-    defaults["backend"] = "mkvtoolnix"
-    cmd = build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=False)
+    defaults.backend = "mkvtoolnix"
+    cmd = build_cmd(src, dst, tracks, defaults, wipe_forced=False, wipe_all=False)
     assert cmd == [
         "mkvmerge",
         "--forced-track",


### PR DESCRIPTION
## Summary
- add `AppConfig` dataclass to hold configuration
- return an `AppConfig` instance from `load_config`
- update tracks module and GUI logic to use the config object
- adjust tests for new configuration handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437414c9248323a5829fd8a6954061