### PR TITLE
Fade skipped rows

### DIFF
--- a/gui/models.py
+++ b/gui/models.py
@@ -66,6 +66,9 @@ class TrackTableModel(QAbstractTableModel):
                 or getattr(t, "default_subtitle", False)
             ):
                 return self._change_tint
+        if role == Qt.ForegroundRole and getattr(t, "removed", False):
+            col = QColor("#888888")
+            return col
         if role == Qt.ToolTipRole:
             if c == 5:
                 cur = getattr(t, "forced", False)

--- a/gui/widgets/flag_delegate.py
+++ b/gui/widgets/flag_delegate.py
@@ -26,6 +26,11 @@ class FlagDelegate(QStyledItemDelegate):
         opt.state &= ~QStyle.State_HasFocus
 
         painter.save()
+        track_removed = getattr(track, "removed", False)
+        if track_removed:
+            painter.setOpacity(0.4)
+        else:
+            painter.setOpacity(1.0)
         style = opt.widget.style() if opt.widget else QApplication.style()
         style.drawPrimitive(QStyle.PE_PanelItemViewItem, opt, painter, opt.widget)
 

--- a/gui/widgets/keep_toggle_delegate.py
+++ b/gui/widgets/keep_toggle_delegate.py
@@ -19,6 +19,16 @@ class KeepToggleDelegate(QStyledItemDelegate):
         opt.state &= ~QStyle.State_HasFocus
 
         painter.save()
+        track = None
+        if hasattr(index.model(), "track_at_row"):
+            try:
+                track = index.model().track_at_row(index.row())
+            except Exception:
+                track = None
+        if track is not None and getattr(track, "removed", False):
+            painter.setOpacity(0.4)
+        else:
+            painter.setOpacity(1.0)
         style = opt.widget.style() if opt.widget else QApplication.style()
         style.drawPrimitive(QStyle.PE_PanelItemViewItem, opt, painter, opt.widget)
 


### PR DESCRIPTION
## Summary
- fade text color via `Qt.ForegroundRole` for skipped tracks
- lower delegate opacity for skip rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684375fdead48323a51b1038dc49833a