### PR TITLE
Add hotkeys for cycling through groups

### DIFF
--- a/gui/group_logic.py
+++ b/gui/group_logic.py
@@ -92,19 +92,31 @@ class GroupLogic:
                 return i
         return None
 
-    def _on_prev_group(self):
+    def _on_prev_group(self, loop: bool = False):
         idx = self._current_group_idx()
-        if idx is None or idx <= 0:
+        if idx is None:
             return
-        self.group_bar.set_checked(idx - 1)
-        self._on_group_change_idx(idx - 1)
+        if idx <= 0:
+            if not loop:
+                return
+            idx = len(self.group_bar.group_buttons) - 1
+        else:
+            idx -= 1
+        self.group_bar.set_checked(idx)
+        self._on_group_change_idx(idx)
 
-    def _on_next_group(self):
+    def _on_next_group(self, loop: bool = False):
         idx = self._current_group_idx()
-        if idx is None or idx >= len(self.group_bar.group_buttons) - 1:
+        if idx is None:
             return
-        self.group_bar.set_checked(idx + 1)
-        self._on_group_change_idx(idx + 1)
+        if idx >= len(self.group_bar.group_buttons) - 1:
+            if not loop:
+                return
+            idx = 0
+        else:
+            idx += 1
+        self.group_bar.set_checked(idx)
+        self._on_group_change_idx(idx)
 
     def _update_process_buttons(self):
         if not hasattr(self, "group_bar"):

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -5,7 +5,8 @@ from PySide6.QtWidgets import (
     QFileDialog,
     QStatusBar,
 )
-from PySide6.QtCore import QSettings
+from PySide6.QtCore import QSettings, Qt
+from PySide6.QtGui import QKeySequence, QShortcut
 import os
 
 from gui.widgets.group_bar import GroupBar
@@ -47,6 +48,18 @@ class MainWindow(QMainWindow, SettingsLogic, GroupLogic, TableLogic, ActionsLogi
         container = QWidget()
         container.setLayout(main_vbox)
         self.setCentralWidget(container)
+
+        # Keyboard shortcuts for cycling through groups
+        self.shortcut_next_group = QShortcut(QKeySequence("Ctrl+Tab"), self)
+        self.shortcut_next_group.setContext(Qt.ApplicationShortcut)
+        self.shortcut_next_group.activated.connect(
+            lambda: self._on_next_group(loop=True)
+        )
+        self.shortcut_prev_group = QShortcut(QKeySequence("Ctrl+Shift+Tab"), self)
+        self.shortcut_prev_group.setContext(Qt.ApplicationShortcut)
+        self.shortcut_prev_group.activated.connect(
+            lambda: self._on_prev_group(loop=True)
+        )
 
         self.group_bar.preferencesClicked.connect(self._open_preferences)
         self._setup_all_logic()


### PR DESCRIPTION
## Summary
- add keyboard shortcuts to cycle through groups
- allow looped selection when triggered via shortcuts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684379bfad088323928811d30122e584