### PR TITLE
Add Shift+Tab shortcut for previous group

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -60,6 +60,11 @@ class MainWindow(QMainWindow, SettingsLogic, GroupLogic, TableLogic, ActionsLogi
         self.shortcut_prev_group.activated.connect(
             lambda: self._on_prev_group(loop=True)
         )
+        self.shortcut_prev_group_shift = QShortcut(QKeySequence("Shift+Tab"), self)
+        self.shortcut_prev_group_shift.setContext(Qt.ApplicationShortcut)
+        self.shortcut_prev_group_shift.activated.connect(
+            lambda: self._on_prev_group(loop=True)
+        )
 
         self.group_bar.preferencesClicked.connect(self._open_preferences)
         self._setup_all_logic()


### PR DESCRIPTION
## Summary
- extend main window shortcuts so `Shift+Tab` also moves to the previous group

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437ae954808323a39ecea8aafe7f4f