### PR TITLE
Fix missing QPushButton.setTextFormat

### DIFF
--- a/gui/widgets/action_bar.py
+++ b/gui/widgets/action_bar.py
@@ -18,36 +18,31 @@ class ActionBar(QWidget):
         self.btn_open_files = QPushButton("📂 Open Files...")
         self.btn_open_files.setToolTip("Choose one or more MKV videos.")
 
-        # Use rich text so Qt actually renders the markup for shortcut letters
+        # Underline shortcut letters using HTML markup
         self.btn_def_audio = QPushButton("🔊 Default <b><u>A</u></b>udio")
-        self.btn_def_audio.setTextFormat(Qt.RichText)
         self.btn_def_audio.setToolTip(
             "Set which audio track should play by default."
         )
         self.btn_def_audio.setShortcut(QKeySequence("A"))
 
         self.btn_def_sub = QPushButton("💬 Default <b><u>S</u></b>ubtitle")
-        self.btn_def_sub.setTextFormat(Qt.RichText)
         self.btn_def_sub.setToolTip(
             "Set which subtitle track is shown automatically."
         )
         self.btn_def_sub.setShortcut(QKeySequence("S"))
 
         self.btn_forced = QPushButton("🏳️‍🌈 Set <b><u>F</u></b>orced")
-        self.btn_forced.setTextFormat(Qt.RichText)
         self.btn_forced.setToolTip(
             "Mark selected subtitles as forced so players show them."
         )
         self.btn_forced.setShortcut(QKeySequence("F"))
 
         self.btn_wipe_all = QPushButton("🧹 <b><u>W</u></b>ipe All Subs")
-        self.btn_wipe_all.setTextFormat(Qt.RichText)
         self.btn_wipe_all.setToolTip("Remove every subtitle from these videos.")
         # Allow toggling so the state can be used when processing files
         self.btn_wipe_all.setCheckable(True)
         self.btn_wipe_all.setShortcut(QKeySequence("W"))
         self.btn_preview = QPushButton("👁️ <b><u>P</u></b>review Subtitle")
-        self.btn_preview.setTextFormat(Qt.RichText)
         self.btn_preview.setToolTip("Quickly check the subtitles before processing.")
         self.btn_preview.setShortcut(QKeySequence("P"))
 


### PR DESCRIPTION
## Summary
- remove calls to QPushButton.setTextFormat, which is not available in PySide6
- keep underline markup in button text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437de342e083239dce27f2fc7259b2