### PR TITLE
Add keyboard shortcut module

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -6,7 +6,6 @@ from PySide6.QtWidgets import (
     QStatusBar,
 )
 from PySide6.QtCore import QSettings, Qt
-from PySide6.QtGui import QKeySequence, QShortcut
 import os
 
 from gui.widgets.group_bar import GroupBar
@@ -18,9 +17,10 @@ from .settings_logic import SettingsLogic
 from .group_logic import GroupLogic
 from .table_logic import TableLogic
 from .actions_logic import ActionsLogic
+from .shortcut_logic import ShortcutLogic
 
 
-class MainWindow(QMainWindow, SettingsLogic, GroupLogic, TableLogic, ActionsLogic):
+class MainWindow(QMainWindow, SettingsLogic, GroupLogic, TableLogic, ActionsLogic, ShortcutLogic):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("MKV Cleaner")
@@ -49,22 +49,7 @@ class MainWindow(QMainWindow, SettingsLogic, GroupLogic, TableLogic, ActionsLogi
         container.setLayout(main_vbox)
         self.setCentralWidget(container)
 
-        # Keyboard shortcuts for cycling through groups
-        self.shortcut_next_group = QShortcut(QKeySequence("Ctrl+Tab"), self)
-        self.shortcut_next_group.setContext(Qt.ApplicationShortcut)
-        self.shortcut_next_group.activated.connect(
-            lambda: self._on_next_group(loop=True)
-        )
-        self.shortcut_prev_group = QShortcut(QKeySequence("Ctrl+Shift+Tab"), self)
-        self.shortcut_prev_group.setContext(Qt.ApplicationShortcut)
-        self.shortcut_prev_group.activated.connect(
-            lambda: self._on_prev_group(loop=True)
-        )
-        self.shortcut_prev_group_shift = QShortcut(QKeySequence("Shift+Tab"), self)
-        self.shortcut_prev_group_shift.setContext(Qt.ApplicationShortcut)
-        self.shortcut_prev_group_shift.activated.connect(
-            lambda: self._on_prev_group(loop=True)
-        )
+
 
         self.group_bar.preferencesClicked.connect(self._open_preferences)
         self._setup_all_logic()
@@ -75,6 +60,7 @@ class MainWindow(QMainWindow, SettingsLogic, GroupLogic, TableLogic, ActionsLogi
         self._setup_group_logic()
         self._setup_table_logic()
         self._setup_action_logic()
+        self._setup_shortcut_logic()
 
     def _adjust_window_width(self):
         """Shrink the window horizontally to the width required by the action bar."""

--- a/gui/shortcut_logic.py
+++ b/gui/shortcut_logic.py
@@ -1,0 +1,65 @@
+from PySide6.QtGui import QKeySequence, QShortcut
+from PySide6.QtCore import Qt
+
+
+class ShortcutLogic:
+    def _setup_shortcut_logic(self):
+        """Create application shortcuts and connect them to actions."""
+        # Navigate between groups
+        self.shortcut_next_group = QShortcut(QKeySequence("Ctrl+Tab"), self)
+        self.shortcut_next_group.setContext(Qt.ApplicationShortcut)
+        self.shortcut_next_group.activated.connect(
+            lambda: self._on_next_group(loop=True)
+        )
+        self.shortcut_prev_group = QShortcut(QKeySequence("Ctrl+Shift+Tab"), self)
+        self.shortcut_prev_group.setContext(Qt.ApplicationShortcut)
+        self.shortcut_prev_group.activated.connect(
+            lambda: self._on_prev_group(loop=True)
+        )
+        self.shortcut_prev_group_shift = QShortcut(QKeySequence("Shift+Tab"), self)
+        self.shortcut_prev_group_shift.setContext(Qt.ApplicationShortcut)
+        self.shortcut_prev_group_shift.activated.connect(
+            lambda: self._on_prev_group(loop=True)
+        )
+
+        # Action bar shortcuts
+        if hasattr(self, "action_bar"):
+            ab = self.action_bar
+            sc = QShortcut(QKeySequence("A"), self)
+            sc.setContext(Qt.ApplicationShortcut)
+            sc.activated.connect(ab.btn_def_audio.click)
+
+            sc = QShortcut(QKeySequence("S"), self)
+            sc.setContext(Qt.ApplicationShortcut)
+            sc.activated.connect(ab.btn_def_sub.click)
+
+            sc = QShortcut(QKeySequence("F"), self)
+            sc.setContext(Qt.ApplicationShortcut)
+            sc.activated.connect(ab.btn_forced.click)
+
+            sc = QShortcut(QKeySequence("W"), self)
+            sc.setContext(Qt.ApplicationShortcut)
+            sc.activated.connect(
+                lambda: ab.btn_wipe_all.setChecked(not ab.btn_wipe_all.isChecked())
+            )
+
+            sc = QShortcut(QKeySequence("P"), self)
+            sc.setContext(Qt.ApplicationShortcut)
+            sc.activated.connect(ab.btn_preview.click)
+
+        # Toggle keep/skip on the selected track
+        if hasattr(self, "track_table"):
+            sc = QShortcut(QKeySequence(Qt.Key_Space), self.track_table)
+            sc.setContext(Qt.WidgetWithChildrenShortcut)
+            sc.activated.connect(self._toggle_keep_selected)
+            self.shortcut_toggle_keep = sc
+
+    def _toggle_keep_selected(self):
+        row = self._current_idx()
+        if row is None:
+            return
+        model = self.track_table.table_model
+        idx = model.index(row, 0)
+        state = model.data(idx, Qt.CheckStateRole)
+        new_state = Qt.Unchecked if state == Qt.Checked else Qt.Checked
+        model.setData(idx, new_state, Qt.CheckStateRole)

--- a/gui/widgets/action_bar.py
+++ b/gui/widgets/action_bar.py
@@ -1,5 +1,4 @@
 from PySide6.QtWidgets import QWidget, QHBoxLayout, QPushButton
-from PySide6.QtGui import QKeySequence
 from PySide6.QtCore import Qt
 
 from .fade_disabled import apply_fade_on_disable
@@ -23,28 +22,23 @@ class ActionBar(QWidget):
         self.btn_def_audio.setToolTip(
             "Set which audio track should play by default."
         )
-        self.btn_def_audio.setShortcut(QKeySequence("A"))
 
         self.btn_def_sub = QPushButton("💬 Default &Subtitle")
         self.btn_def_sub.setToolTip(
             "Set which subtitle track is shown automatically."
         )
-        self.btn_def_sub.setShortcut(QKeySequence("S"))
 
         self.btn_forced = QPushButton("🏳️‍🌈 Set &Forced")
         self.btn_forced.setToolTip(
             "Mark selected subtitles as forced so players show them."
         )
-        self.btn_forced.setShortcut(QKeySequence("F"))
 
         self.btn_wipe_all = QPushButton("🧹 &Wipe All Subs")
         self.btn_wipe_all.setToolTip("Remove every subtitle from these videos.")
         # Allow toggling so the state can be used when processing files
         self.btn_wipe_all.setCheckable(True)
-        self.btn_wipe_all.setShortcut(QKeySequence("W"))
         self.btn_preview = QPushButton("👁️ &Preview Subtitle")
         self.btn_preview.setToolTip("Quickly check the subtitles before processing.")
-        self.btn_preview.setShortcut(QKeySequence("P"))
 
 
         for btn in (
@@ -57,6 +51,7 @@ class ActionBar(QWidget):
         ):
             btn.setMinimumHeight(38)
             btn.setMinimumWidth(110)
+            btn.setFocusPolicy(Qt.NoFocus)
             btn.setStyleSheet(
                 "QPushButton { font-weight: 500; font-size: 14px;" +
                 " border-radius: 8px; padding: 5px 10px; }"


### PR DESCRIPTION
## Summary
- move window shortcuts to new `ShortcutLogic`
- allow space to toggle keep/skip for the selected track
- prevent buttons from stealing table focus

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684382c05908832392ac5b37fba8a842