### PR TITLE
Improve keyboard shortcuts and subtitle preview

### DIFF
--- a/gui/shortcut_logic.py
+++ b/gui/shortcut_logic.py
@@ -39,13 +39,40 @@ class ShortcutLogic:
 
             sc = QShortcut(QKeySequence("W"), self)
             sc.setContext(Qt.ApplicationShortcut)
-            sc.activated.connect(
-                lambda: ab.btn_wipe_all.setChecked(not ab.btn_wipe_all.isChecked())
-            )
+            sc.activated.connect(lambda: ab.btn_wipe_all.isEnabled() and ab.btn_wipe_all.click())
+
+            sc = QShortcut(QKeySequence("O"), self)
+            sc.setContext(Qt.ApplicationShortcut)
+            sc.activated.connect(lambda: ab.btn_open_files.isEnabled() and ab.btn_open_files.click())
+
+            sc = QShortcut(QKeySequence("Ctrl+O"), self)
+            sc.setContext(Qt.ApplicationShortcut)
+            sc.activated.connect(lambda: ab.btn_open_files.isEnabled() and ab.btn_open_files.click())
+
+            if hasattr(self.group_bar, "btn_process_group"):
+                sc = QShortcut(QKeySequence("Ctrl+G"), self)
+                sc.setContext(Qt.ApplicationShortcut)
+                sc.activated.connect(lambda: self.group_bar.btn_process_group.isEnabled() and self.group_bar.btn_process_group.click())
+
+            if hasattr(self.group_bar, "btn_process_all"):
+                sc = QShortcut(QKeySequence("Ctrl+Return"), self)
+                sc.setContext(Qt.ApplicationShortcut)
+                sc.activated.connect(lambda: self.group_bar.btn_process_all.isEnabled() and self.group_bar.btn_process_all.click())
+
+            sc = QShortcut(QKeySequence(Qt.Key_Escape), self)
+            sc.setContext(Qt.ApplicationShortcut)
+            sc.activated.connect(self._open_preferences)
 
             sc = QShortcut(QKeySequence("P"), self)
             sc.setContext(Qt.ApplicationShortcut)
             sc.activated.connect(ab.btn_preview.click)
+
+        # Number keys for selecting groups
+        if hasattr(self, "group_bar"):
+            for i in range(1, 10):
+                sc = QShortcut(QKeySequence(str(i)), self)
+                sc.setContext(Qt.ApplicationShortcut)
+                sc.activated.connect(lambda i=i: self._activate_group_index(i - 1))
 
         # Toggle keep/skip on the selected track
         if hasattr(self, "track_table"):
@@ -63,3 +90,10 @@ class ShortcutLogic:
         state = model.data(idx, Qt.CheckStateRole)
         new_state = Qt.Unchecked if state == Qt.Checked else Qt.Checked
         model.setData(idx, new_state, Qt.CheckStateRole)
+
+    def _activate_group_index(self, idx: int) -> None:
+        if not hasattr(self, "group_bar"):
+            return
+        btn = self.group_bar.button_at(idx)
+        if btn and btn.isEnabled():
+            btn.click()

--- a/gui/table_logic.py
+++ b/gui/table_logic.py
@@ -9,6 +9,7 @@ class TableLogic:
         self.track_table.table_model.modelReset.connect(
             lambda: self._on_selection_change(self.track_table.currentIndex(), None)
         )
+        self.track_table.doubleClicked.connect(self._on_table_double_clicked)
         self._on_selection_change(self.track_table.currentIndex(), None)
 
     def _on_table_clicked(self, index):
@@ -40,3 +41,10 @@ class TableLogic:
     def _current_idx(self):
         ci = self.track_table.currentIndex()
         return None if not ci.isValid() else ci.row()
+
+    def _on_table_double_clicked(self, index):
+        if not index.isValid():
+            return
+        t = self.track_table.table_model.track_at_row(index.row())
+        if t.type == "subtitles" and self.action_bar.btn_preview.isEnabled():
+            self.preview_subtitle()


### PR DESCRIPTION
## Summary
- tweak wipe-all shortcut to actually trigger the toggle
- add shortcuts for opening files, processing and preferences
- map 1-9 keys to select groups
- open subtitle preview on double-click
- change group processing shortcut to Ctrl+G

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843853cf9c08323816a0de27e99e3cd