### PR TITLE
Enable wiping subtitles without a selected track

### DIFF
--- a/gui/table_logic.py
+++ b/gui/table_logic.py
@@ -19,24 +19,39 @@ class TableLogic:
         self._on_selection_change(self.track_table.currentIndex(), None)
 
     def _on_selection_change(self, current, _):
+        ab = self.action_bar
         for btn in (
-            self.action_bar.btn_def_audio, self.action_bar.btn_def_sub, self.action_bar.btn_forced,
-            self.action_bar.btn_wipe_all, self.action_bar.btn_preview
+            ab.btn_def_audio,
+            ab.btn_def_sub,
+            ab.btn_forced,
+            ab.btn_wipe_all,
+            ab.btn_preview,
         ):
             btn.setEnabled(False)
+
+        # Enable wipe all when a group is active and has subtitle tracks
+        sig = getattr(self, "current_sig", None)
+        if sig is not None:
+            tracks = getattr(self, "groups", {}).get(sig, [])
+            if any(t.type == "subtitles" for t in tracks):
+                ab.btn_wipe_all.setEnabled(True)
+
         if not current.isValid():
             return
+
         t = self.track_table.table_model.track_at_row(current.row())
         if t.removed:
-            self.action_bar.btn_wipe_all.setEnabled(t.type == "subtitles")
+            if t.type == "subtitles":
+                ab.btn_wipe_all.setEnabled(True)
             return
+
         if t.type == "audio":
-            self.action_bar.btn_def_audio.setEnabled(True)
+            ab.btn_def_audio.setEnabled(True)
         elif t.type == "subtitles":
-            self.action_bar.btn_def_sub.setEnabled(True)
-            self.action_bar.btn_forced.setEnabled(True)
-            self.action_bar.btn_wipe_all.setEnabled(True)
-            self.action_bar.btn_preview.setEnabled(True)
+            ab.btn_def_sub.setEnabled(True)
+            ab.btn_forced.setEnabled(True)
+            ab.btn_wipe_all.setEnabled(True)
+            ab.btn_preview.setEnabled(True)
 
     def _current_idx(self):
         ci = self.track_table.currentIndex()

--- a/tests/test_table_logic.py
+++ b/tests/test_table_logic.py
@@ -1,0 +1,66 @@
+import types
+import sys
+
+# Stub PySide6 modules
+sys.modules['PySide6'] = types.ModuleType('PySide6')
+qtcore = types.ModuleType('PySide6.QtCore')
+qtcore.Qt = type('Qt', (), {})
+sys.modules['PySide6.QtCore'] = qtcore
+
+from gui.table_logic import TableLogic
+from core.tracks import Track
+
+class DummyButton:
+    def __init__(self):
+        self.enabled = False
+    def setEnabled(self, val):
+        self.enabled = val
+    def isEnabled(self):
+        return self.enabled
+
+class DummyActionBar:
+    def __init__(self):
+        self.btn_def_audio = DummyButton()
+        self.btn_def_sub = DummyButton()
+        self.btn_forced = DummyButton()
+        self.btn_wipe_all = DummyButton()
+        self.btn_preview = DummyButton()
+
+class DummyModel:
+    def __init__(self, tracks):
+        self.tracks = tracks
+    def update_tracks(self, tracks):
+        self.tracks = tracks
+    def track_at_row(self, row):
+        return self.tracks[row]
+    def get_tracks(self):
+        return self.tracks
+
+class DummyTrackTable:
+    def __init__(self, tracks):
+        self.table_model = DummyModel(tracks)
+
+class DummyIndex:
+    def __init__(self, valid=False, row=0):
+        self._valid = valid
+        self._row = row
+    def isValid(self):
+        return self._valid
+    def row(self):
+        return self._row
+
+class DummyWindow(TableLogic):
+    def __init__(self, tracks):
+        self.action_bar = DummyActionBar()
+        self.track_table = DummyTrackTable(tracks)
+        self.groups = {"g1": tracks}
+        self.current_sig = "g1"
+
+def test_wipe_all_enabled_without_selection():
+    tracks = [
+        Track(idx=0, tid=1, type="subtitles", codec="srt", language="eng", forced=False, name="Eng"),
+        Track(idx=1, tid=2, type="audio", codec="aac", language="eng", forced=False, name="Au"),
+    ]
+    win = DummyWindow(tracks)
+    win._on_selection_change(DummyIndex(valid=False), None)
+    assert win.action_bar.btn_wipe_all.isEnabled() is True


### PR DESCRIPTION
## Summary
- allow `Wipe All Subs` regardless of track selection if a group is active
- add regression test for table logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843892fcbb0832397fc952218e31f37