### PR TITLE
Fix missing hotkey tooltips

### DIFF
--- a/gui/shortcut_logic.py
+++ b/gui/shortcut_logic.py
@@ -14,11 +14,12 @@ class ShortcutLogic:
             return
         tip = widget.toolTip() or ""
         seq = shortcut.key().toString(QKeySequence.NativeText)
-        if seq in tip:
+        hotkey_line = f"Hotkey: {seq}"
+        if hotkey_line in tip:
             return
         if tip and not tip.endswith("\n"):
             tip += "\n"
-        tip += f"Hotkey: {seq}"
+        tip += hotkey_line
         widget.setToolTip(tip)
 
     def _register_shortcut(self, name: str, shortcut: QShortcut, widget=None) -> None:


### PR DESCRIPTION
## Summary
- ensure hotkey tooltips only check for existing full line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843898eb8c48323b94d2ddf214f5637