### PR TITLE
Fix track selection retention

### DIFF
--- a/gui/actions_logic.py
+++ b/gui/actions_logic.py
@@ -41,6 +41,7 @@ class ActionsLogic:
                 tr.default_audio = False
         t.default_audio = True
         self.track_table.table_model.update_tracks(self.track_table.table_model.tracks)
+        self.track_table.selectRow(row)
         if hasattr(self, "status_bar"):
             msg = f"Default audio set to track {t.tid} ({t.language})"
             if t.name:
@@ -59,6 +60,7 @@ class ActionsLogic:
                 tr.default_subtitle = False
         t.default_subtitle = True
         self.track_table.table_model.update_tracks(self.track_table.table_model.tracks)
+        self.track_table.selectRow(row)
         if hasattr(self, "status_bar"):
             msg = f"Default subtitle set to track {t.tid} ({t.language})"
             if t.name:
@@ -82,6 +84,7 @@ class ActionsLogic:
             t.forced = False
             state = "disabled"
         self.track_table.table_model.update_tracks(self.track_table.table_model.tracks)
+        self.track_table.selectRow(row)
         if hasattr(self, "status_bar"):
             msg = f"Forced flag {state} on track {t.tid} ({t.language})"
             if t.name:
@@ -92,6 +95,8 @@ class ActionsLogic:
         sig = getattr(self, "current_sig", None)
         if sig is None:
             return
+
+        row = self._current_idx()
 
         btn = getattr(getattr(self, "action_bar", None), "btn_wipe_all", None)
         wiping = btn.isChecked() if btn is not None else True
@@ -120,6 +125,8 @@ class ActionsLogic:
             self.track_table.table_model.update_tracks(
                 self.track_table.table_model.tracks
             )
+            if row is not None:
+                self.track_table.selectRow(row)
             if hasattr(self, "status_bar"):
                 self.status_bar.showMessage(msg, 2000)
 

--- a/tests/test_actions_logic.py
+++ b/tests/test_actions_logic.py
@@ -44,6 +44,10 @@ class DummyModel:
 class DummyTrackTable:
     def __init__(self, tracks):
         self.table_model = DummyModel(tracks)
+        self.selected = None
+
+    def selectRow(self, row):
+        self.selected = row
 
 class DummyButton:
     def __init__(self):
@@ -89,6 +93,31 @@ def test_only_one_forced_subtitle():
     actions.set_forced_subtitle()
     assert tracks[0].forced is False
     assert tracks[1].forced is False
+
+
+def test_selection_preserved_after_actions():
+    tracks = [
+        Track(idx=0, tid=1, type="subtitles", codec="srt", language="eng", forced=False, name="English"),
+        Track(idx=1, tid=2, type="subtitles", codec="srt", language="spa", forced=False, name="Spanish"),
+        Track(idx=2, tid=3, type="audio", codec="aac", language="eng", forced=False, name="Audio"),
+    ]
+    actions = DummyActions(tracks)
+
+    actions.cur_idx = 1
+    actions.set_default_subtitle()
+    assert actions.track_table.selected == 1
+
+    actions.set_forced_subtitle()
+    assert actions.track_table.selected == 1
+
+    actions.cur_idx = 2
+    actions.set_default_audio()
+    assert actions.track_table.selected == 2
+
+    actions.cur_idx = 1
+    actions.action_bar.btn_wipe_all.setChecked(True)
+    actions.wipe_all_subs()
+    assert actions.track_table.selected == 1
 
 
 def test_wipe_all_toggle_restores_tracks():


### PR DESCRIPTION
## Summary
- keep track selection after performing actions
- test that selection persists when running actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684389db968c8323845eaf0a09b0ec77