### PR TITLE
Add arrow and deletion hotkeys

### DIFF
--- a/gui/group_logic.py
+++ b/gui/group_logic.py
@@ -129,3 +129,15 @@ class GroupLogic:
         if hasattr(self.group_bar, "btn_process_all"):
             has_files = any(self.file_groups.values())
             self.group_bar.btn_process_all.setEnabled(has_files)
+
+    def _empty_current_group(self) -> None:
+        """Remove all files from the currently selected group."""
+        sig = getattr(self, "current_sig", None)
+        if sig is None:
+            return
+        if sig in self.file_groups:
+            self.file_groups[sig] = []
+        if hasattr(self, "file_list"):
+            self.file_list.update_files([])
+        self.group_bar.update_button_tooltip(sig, "")
+        self._update_process_buttons()

--- a/gui/shortcut_logic.py
+++ b/gui/shortcut_logic.py
@@ -47,6 +47,16 @@ class ShortcutLogic:
         sc.activated.connect(lambda: self._on_prev_group(loop=True))
         self._register_shortcut("Previous group", sc)
 
+        sc = QShortcut(QKeySequence(Qt.Key_Right), self)
+        sc.setContext(Qt.ApplicationShortcut)
+        sc.activated.connect(self._on_next_group)
+        self._register_shortcut("Next group", sc)
+
+        sc = QShortcut(QKeySequence(Qt.Key_Left), self)
+        sc.setContext(Qt.ApplicationShortcut)
+        sc.activated.connect(self._on_prev_group)
+        self._register_shortcut("Previous group", sc)
+
         # Action bar shortcuts
         if hasattr(self, "action_bar"):
             ab = self.action_bar
@@ -123,6 +133,26 @@ class ShortcutLogic:
             self.shortcut_toggle_keep = sc
             self._register_shortcut("Toggle keep track", sc)
 
+            sc = QShortcut(QKeySequence(Qt.Key_Up), self)
+            sc.setContext(Qt.ApplicationShortcut)
+            sc.activated.connect(self._on_prev_track)
+            self._register_shortcut("Previous track", sc)
+
+            sc = QShortcut(QKeySequence(Qt.Key_Down), self)
+            sc.setContext(Qt.ApplicationShortcut)
+            sc.activated.connect(self._on_next_track)
+            self._register_shortcut("Next track", sc)
+
+            sc = QShortcut(QKeySequence(Qt.Key_Backspace), self)
+            sc.setContext(Qt.ApplicationShortcut)
+            sc.activated.connect(self._empty_current_group)
+            self._register_shortcut("Empty group", sc)
+
+            sc = QShortcut(QKeySequence(Qt.Key_Delete), self)
+            sc.setContext(Qt.ApplicationShortcut)
+            sc.activated.connect(self._empty_current_group)
+            self._register_shortcut("Empty group", sc)
+
     def _toggle_keep_selected(self):
         row = self._current_idx()
         if row is None:
@@ -139,3 +169,29 @@ class ShortcutLogic:
         btn = self.group_bar.button_at(idx)
         if btn and btn.isEnabled():
             btn.click()
+
+    def _on_prev_track(self) -> None:
+        if not hasattr(self, "track_table"):
+            return
+        row = self._current_idx()
+        model = self.track_table.table_model
+        count = model.rowCount()
+        if count == 0:
+            return
+        if row is None:
+            self.track_table.selectRow(0)
+        elif row > 0:
+            self.track_table.selectRow(row - 1)
+
+    def _on_next_track(self) -> None:
+        if not hasattr(self, "track_table"):
+            return
+        row = self._current_idx()
+        model = self.track_table.table_model
+        count = model.rowCount()
+        if count == 0:
+            return
+        if row is None:
+            self.track_table.selectRow(0)
+        elif row < count - 1:
+            self.track_table.selectRow(row + 1)

--- a/tests/test_group_logic.py
+++ b/tests/test_group_logic.py
@@ -85,3 +85,18 @@ def test_button_click_triggers_once(monkeypatch):
     btn.clicked.emit(False)
 
     assert len(calls) == 1
+
+
+def test_empty_current_group():
+    logic = GroupLogic()
+    logic.group_bar = DummyGroupBar()
+    logic.track_table = DummyTrackTable()
+    logic.file_list = type("FL", (), {"update_files": lambda self, f: None, "clear": lambda self: None})()
+    logic._setup_group_logic()
+    logic.groups["sig1"] = []
+    logic.file_groups["sig1"] = ["f1", "f2"]
+    logic.current_sig = "sig1"
+
+    logic._empty_current_group()
+
+    assert logic.file_groups["sig1"] == []


### PR DESCRIPTION
## Summary
- add function to clear files from current group
- enable left/right arrows for group navigation without looping
- support up/down arrows for track selection
- allow backspace/delete to empty the active group
- test clearing of current group

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438bcf9cdc8323a024512cae1a7aed