### PR TITLE
Show modal progress dialog

### DIFF
--- a/gui/processing.py
+++ b/gui/processing.py
@@ -9,9 +9,13 @@ from pathlib import Path
 def process_files(jobs, max_workers, query_tracks, build_cmd, run_command, output_dir, wipe_all_flag, parent=None):
     """Process multiple files in parallel and report progress/errors in the GUI."""
     dlg = QProgressDialog("Processing...", "Cancel", 0, len(jobs), parent)
-    dlg.setWindowModality(Qt.WindowModal)
+    dlg.setWindowModality(Qt.ApplicationModal)
     dlg.setMinimumDuration(0)
     dlg.setValue(0)
+    dlg.show()
+    dlg.activateWindow()
+    if parent is not None:
+        parent.setEnabled(False)
 
     errors = []
     import threading
@@ -58,6 +62,8 @@ def process_files(jobs, max_workers, query_tracks, build_cmd, run_command, outpu
                 break
 
     dlg.close()
+    if parent is not None:
+        parent.setEnabled(True)
 
     if errors:
         msg = "\n".join([f"{f}: {err}" for f, err in errors])

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -9,7 +9,7 @@ sys.modules['PySide6'] = types.ModuleType('PySide6')
 qtcore = types.ModuleType('PySide6.QtCore')
 qtcore.QMetaObject = type('QMetaObject', (), {'invokeMethod': lambda *a, **k: None})
 qtcore.Q_ARG = lambda typ, val: val
-qtcore.Qt = type('Qt', (), {'WindowModal': 0, 'QueuedConnection': 0})
+qtcore.Qt = type('Qt', (), {'WindowModal': 0, 'ApplicationModal': 1, 'QueuedConnection': 0})
 sys.modules['PySide6.QtCore'] = qtcore
 
 qtwidgets = types.ModuleType('PySide6.QtWidgets')
@@ -20,7 +20,9 @@ qtwidgets.QMessageBox = type('QMessageBox', (), {
 })
 sys.modules['PySide6.QtWidgets'] = qtwidgets
 
+import importlib
 import gui.processing as processing  # noqa: E402
+processing = importlib.reload(processing)
 
 
 class DummyDialog:
@@ -43,6 +45,12 @@ class DummyDialog:
         return self._canceled
 
     def close(self):
+        pass
+
+    def show(self):
+        pass
+
+    def activateWindow(self):
         pass
 
 


### PR DESCRIPTION
## Summary
- keep main window disabled while processing
- ensure processing dialog grabs focus
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438ccfa08083239c57924193480ca7