### PR TITLE
Ensure empty groups are removed

### DIFF
--- a/gui/widgets/group_bar.py
+++ b/gui/widgets/group_bar.py
@@ -142,6 +142,18 @@ class GroupBar(QWidget):
         self.group_buttons.append((sig, btn))
         return btn
 
+    def remove_group_button(self, sig):
+        for i, (s, btn) in enumerate(self.group_buttons):
+            if s == sig:
+                self.layout.removeWidget(btn)
+                btn.deleteLater()
+                self.button_group.removeButton(btn)
+                self.group_buttons.pop(i)
+                break
+        for j, (_, b) in enumerate(self.group_buttons):
+            b.setText(str(j + 1))
+        self.update_nav_buttons(None)
+
     def update_button_tooltip(self, sig, tooltip):
         for s, b in self.group_buttons:
             if s == sig:

--- a/tests/test_group_logic.py
+++ b/tests/test_group_logic.py
@@ -34,6 +34,12 @@ class DummyGroupBar:
         self.group_buttons.append((sig, btn))
         return btn
 
+    def remove_group_button(self, sig):
+        for i, (s, _) in enumerate(self.group_buttons):
+            if s == sig:
+                self.group_buttons.pop(i)
+                break
+
     def update_button_tooltip(self, sig, tooltip):
         pass
 
@@ -99,4 +105,7 @@ def test_empty_current_group():
 
     logic._empty_current_group()
 
-    assert logic.file_groups["sig1"] == []
+    assert "sig1" not in logic.file_groups
+    assert "sig1" not in logic.groups
+    assert logic.current_sig is None
+    assert not logic.group_bar.group_buttons


### PR DESCRIPTION
## Summary
- delete a group when its file list is emptied
- allow GroupBar to remove buttons
- update group logic tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438d8b9618832398b1816ef9a22d07