### PR TITLE
Update progress dialog to logo splash

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include fonts/*
+include MKV-Cleaner_logo.png

--- a/gui/processing.py
+++ b/gui/processing.py
@@ -1,17 +1,43 @@
 from PySide6.QtCore import QMetaObject, Q_ARG, Qt
-from PySide6.QtWidgets import QProgressDialog, QMessageBox
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import QWidget, QLabel, QVBoxLayout, QMessageBox
+from pathlib import Path
 import logging
+
+
+class LogoSplash(QWidget):
+    """Simple splash screen showing the application logo."""
+
+    def __init__(self, parent=None):
+        super().__init__(None, Qt.FramelessWindowHint | Qt.SplashScreen)
+        pixmap = QPixmap(str(Path(__file__).resolve().parent.parent / "MKV-Cleaner_logo.png"))
+        if parent is not None:
+            max_size = parent.size()
+            if pixmap.width() > max_size.width() or pixmap.height() > max_size.height():
+                pixmap = pixmap.scaled(max_size, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        label = QLabel(self)
+        label.setPixmap(pixmap)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(label)
+        self.setFixedSize(pixmap.size())
+        if parent is not None:
+            center = parent.geometry().center()
+            self.move(center.x() - self.width() // 2, center.y() - self.height() // 2)
+        self._canceled = False
+
+    def setValue(self, val):
+        pass  # kept for API compatibility
+
+    def wasCanceled(self):
+        return False
 
 logger = logging.getLogger(__name__)
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from pathlib import Path
 
 def process_files(jobs, max_workers, query_tracks, build_cmd, run_command, output_dir, wipe_all_flag, parent=None):
     """Process multiple files in parallel and report progress/errors in the GUI."""
-    dlg = QProgressDialog("Processing...", "Cancel", 0, len(jobs), parent)
-    dlg.setWindowModality(Qt.ApplicationModal)
-    dlg.setMinimumDuration(0)
-    dlg.setValue(0)
+    dlg = LogoSplash(parent)
     dlg.show()
     dlg.activateWindow()
     if parent is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ py-modules = ["mkv_cleaner"]
 
 [tool.setuptools.data-files]
 "fonts" = ["fonts/*"]
+"" = ["MKV-Cleaner_logo.png"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_actions_logic.py
+++ b/tests/test_actions_logic.py
@@ -17,10 +17,13 @@ qtwidgets.QMessageBox = type('QMessageBox', (), {
 # Additional classes used by subtitle_preview imports
 for cls in (
     'QMainWindow', 'QTextEdit', 'QHBoxLayout', 'QVBoxLayout',
-    'QWidget', 'QPushButton', 'QProgressDialog'
+    'QWidget', 'QPushButton', 'QLabel', 'LogoSplash'
 ):
     setattr(qtwidgets, cls, object)
 sys.modules['PySide6.QtWidgets'] = qtwidgets
+qtgui = types.ModuleType('PySide6.QtGui')
+qtgui.QPixmap = object
+sys.modules['PySide6.QtGui'] = qtgui
 
 from gui.actions_logic import ActionsLogic
 from core.tracks import Track

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -13,12 +13,18 @@ qtcore.Qt = type('Qt', (), {'WindowModal': 0, 'ApplicationModal': 1, 'QueuedConn
 sys.modules['PySide6.QtCore'] = qtcore
 
 qtwidgets = types.ModuleType('PySide6.QtWidgets')
-qtwidgets.QProgressDialog = object
+qtwidgets.LogoSplash = object
+qtwidgets.QWidget = object
+qtwidgets.QLabel = object
+qtwidgets.QVBoxLayout = object
 qtwidgets.QMessageBox = type('QMessageBox', (), {
     'warning': staticmethod(lambda *a, **k: None),
     'information': staticmethod(lambda *a, **k: None),
 })
 sys.modules['PySide6.QtWidgets'] = qtwidgets
+qtgui = types.ModuleType('PySide6.QtGui')
+qtgui.QPixmap = object
+sys.modules['PySide6.QtGui'] = qtgui
 
 import importlib
 import gui.processing as processing  # noqa: E402
@@ -112,7 +118,7 @@ def test_cancel_shutdown(monkeypatch):
 
     dlg = DummyDialog()
 
-    monkeypatch.setattr(processing, "QProgressDialog", lambda *a, **kw: dlg)
+    monkeypatch.setattr(processing, "LogoSplash", lambda *a, **kw: dlg)
     monkeypatch.setattr(processing, "QMetaObject", type("_", (), {"invokeMethod": lambda *a: a[0].setValue(a[3])}))
     monkeypatch.setattr(processing, "Q_ARG", lambda *a: a[1])
     exec_instance = DummyExecutor()
@@ -143,7 +149,7 @@ def test_output_dir_created(monkeypatch, tmp_path):
 
     dlg = DummyDialog()
 
-    monkeypatch.setattr(processing, "QProgressDialog", lambda *a, **kw: dlg)
+    monkeypatch.setattr(processing, "LogoSplash", lambda *a, **kw: dlg)
     monkeypatch.setattr(
         processing,
         "QMetaObject",


### PR DESCRIPTION
## Summary
- add the app logo to the distribution
- replace `QProgressDialog` with a borderless splash screen
- adjust unit tests for new splash class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438eac523883239b86bac70c2f80b5