### PR TITLE
Fix progress splash thread update

### DIFF
--- a/gui/processing.py
+++ b/gui/processing.py
@@ -77,7 +77,8 @@ def process_files(jobs, max_workers, query_tracks, build_cmd, run_command, outpu
         return src
 
     def update_progress_in_main_thread(val):
-        QMetaObject.invokeMethod(dlg, "setValue", Qt.QueuedConnection, Q_ARG(int, val))
+        # Directly call setValue since process_files runs in the GUI thread.
+        dlg.setValue(val)
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = [executor.submit(process_one, src, tracks) for src, tracks in jobs]


### PR DESCRIPTION
## Summary
- avoid Qt metaobject invocation for the splash progress update

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843901661b48323bf47c26f795479a5