### PR TITLE
Show startup splash screen

### DIFF
--- a/gui/processing.py
+++ b/gui/processing.py
@@ -1,50 +1,31 @@
-from PySide6.QtCore import QMetaObject, Q_ARG, Qt
-from PySide6.QtGui import QPixmap
-from PySide6.QtWidgets import QWidget, QLabel, QVBoxLayout, QMessageBox
+from PySide6.QtCore import QMetaObject, Q_ARG
+from PySide6.QtWidgets import QMessageBox
 from pathlib import Path
 import logging
 
-
-class LogoSplash(QWidget):
-    """Simple splash screen showing the application logo."""
-
-    def __init__(self, parent=None):
-        super().__init__(None, Qt.FramelessWindowHint | Qt.SplashScreen)
-        pixmap = QPixmap(str(Path(__file__).resolve().parent.parent / "MKV-Cleaner_logo.png"))
-        if parent is not None:
-            max_size = parent.size()
-            if pixmap.width() > max_size.width() or pixmap.height() > max_size.height():
-                pixmap = pixmap.scaled(max_size, Qt.KeepAspectRatio, Qt.SmoothTransformation)
-        label = QLabel(self)
-        label.setPixmap(pixmap)
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(label)
-        self.setFixedSize(pixmap.size())
-        if parent is not None:
-            center = parent.geometry().center()
-            self.move(center.x() - self.width() // 2, center.y() - self.height() // 2)
-        self._canceled = False
-
-    def setValue(self, val):
-        pass  # kept for API compatibility
-
-    def wasCanceled(self):
-        return False
+from .widgets.logo_splash import LogoSplash
 
 logger = logging.getLogger(__name__)
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-def process_files(jobs, max_workers, query_tracks, build_cmd, run_command, output_dir, wipe_all_flag, parent=None):
+
+def process_files(
+    jobs,
+    max_workers,
+    query_tracks,
+    build_cmd,
+    run_command,
+    output_dir,
+    wipe_all_flag,
+    parent=None,
+):
     """Process multiple files in parallel and report progress/errors in the GUI."""
-    dlg = LogoSplash(parent)
-    dlg.show()
-    dlg.activateWindow()
     if parent is not None:
         parent.setEnabled(False)
 
     errors = []
     import threading
+
     lock = threading.Lock()
 
     def process_one(src, tracks):
@@ -64,10 +45,16 @@ def process_files(jobs, max_workers, query_tracks, build_cmd, run_command, outpu
                 t.default_subtitle = False
         # Handle absolute or relative output_dir robustly
         output_dir_path = Path(output_dir)
-        dst_dir = output_dir_path if output_dir_path.is_absolute() else (src.parent / output_dir_path)
+        dst_dir = (
+            output_dir_path
+            if output_dir_path.is_absolute()
+            else (src.parent / output_dir_path)
+        )
         dst_dir.mkdir(parents=True, exist_ok=True)
         dst = dst_dir / src.name
-        cmd = build_cmd(src, dst, real_tracks, wipe_forced=False, wipe_all=wipe_all_flag)
+        cmd = build_cmd(
+            src, dst, real_tracks, wipe_forced=False, wipe_all=wipe_all_flag
+        )
         logger.info("Running: %s", " ".join(map(str, cmd)))
         try:
             run_command(cmd, capture=False)
@@ -76,19 +63,11 @@ def process_files(jobs, max_workers, query_tracks, build_cmd, run_command, outpu
                 errors.append((str(src), str(e)))
         return src
 
-    def update_progress_in_main_thread(val):
-        # Directly call setValue since process_files runs in the GUI thread.
-        dlg.setValue(val)
-
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = [executor.submit(process_one, src, tracks) for src, tracks in jobs]
-        for i, fut in enumerate(as_completed(futures), 1):
-            update_progress_in_main_thread(i)
-            if dlg.wasCanceled():
-                executor.shutdown(cancel_futures=True)
-                break
+        for fut in as_completed(futures):
+            fut.result()
 
-    dlg.close()
     if parent is not None:
         parent.setEnabled(True)
 

--- a/gui/widgets/logo_splash.py
+++ b/gui/widgets/logo_splash.py
@@ -1,0 +1,38 @@
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import QWidget, QLabel, QVBoxLayout
+from pathlib import Path
+
+
+class LogoSplash(QWidget):
+    """Simple splash screen showing the application logo."""
+
+    def __init__(self, parent=None):
+        super().__init__(
+            None, Qt.FramelessWindowHint | Qt.SplashScreen | Qt.WindowStaysOnTopHint
+        )
+        pixmap = QPixmap(
+            str(Path(__file__).resolve().parent.parent / "MKV-Cleaner_logo.png")
+        )
+        if parent is not None:
+            max_size = parent.size()
+            if pixmap.width() > max_size.width() or pixmap.height() > max_size.height():
+                pixmap = pixmap.scaled(
+                    max_size, Qt.KeepAspectRatio, Qt.SmoothTransformation
+                )
+        label = QLabel(self)
+        label.setPixmap(pixmap)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(label)
+        self.setFixedSize(pixmap.size())
+        if parent is not None:
+            center = parent.geometry().center()
+            self.move(center.x() - self.width() // 2, center.y() - self.height() // 2)
+        self._canceled = False
+
+    def setValue(self, val):
+        pass  # kept for API compatibility
+
+    def wasCanceled(self):
+        return False

--- a/mkv_cleaner.py
+++ b/mkv_cleaner.py
@@ -10,16 +10,18 @@ import random
 
 from core.bootstrap import ensure_python_package
 
-ensure_python_package('PySide6')
+ensure_python_package("PySide6")
 if sys.version_info < (3, 11):
-    ensure_python_package('tomli')
+    ensure_python_package("tomli")
 
 from gui.main_window import MainWindow
 from gui.widgets.fast_tooltip_style import FastToolTipStyle
+from gui.widgets.logo_splash import LogoSplash
 from pathlib import Path
 from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QFont, QFontDatabase
-from PySide6.QtCore import QSettings
+from PySide6.QtCore import QSettings, QTimer
+
 
 def set_dynamic_modern_style(app: QApplication) -> None:
     """Apply a dark theme with an accent color to ``app``."""
@@ -36,7 +38,8 @@ def set_dynamic_modern_style(app: QApplication) -> None:
     if not accent:
         accent = random.choice(accents)
 
-    app.setStyleSheet(f"""
+    app.setStyleSheet(
+        f"""
         QMainWindow, QWidget {{
             background-color: #181a20;
             color: #d2e0f0;
@@ -111,7 +114,9 @@ def set_dynamic_modern_style(app: QApplication) -> None:
         #GroupBar QLabel {{
             color: #fff;
         }}
-    """)
+    """
+    )
+
 
 def main() -> None:
     """Create the application and show the main window."""
@@ -136,7 +141,12 @@ def main() -> None:
     set_dynamic_modern_style(app)
     win = MainWindow()
     win.show()
+    splash = LogoSplash(win)
+    splash.show()
+    splash.raise_()
+    QTimer.singleShot(1000, splash.close)
     sys.exit(app.exec())
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -5,29 +5,37 @@ from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import types
-sys.modules['PySide6'] = types.ModuleType('PySide6')
-qtcore = types.ModuleType('PySide6.QtCore')
-qtcore.QMetaObject = type('QMetaObject', (), {'invokeMethod': lambda *a, **k: None})
-qtcore.Q_ARG = lambda typ, val: val
-qtcore.Qt = type('Qt', (), {'WindowModal': 0, 'ApplicationModal': 1, 'QueuedConnection': 0})
-sys.modules['PySide6.QtCore'] = qtcore
 
-qtwidgets = types.ModuleType('PySide6.QtWidgets')
+sys.modules["PySide6"] = types.ModuleType("PySide6")
+qtcore = types.ModuleType("PySide6.QtCore")
+qtcore.QMetaObject = type("QMetaObject", (), {"invokeMethod": lambda *a, **k: None})
+qtcore.Q_ARG = lambda typ, val: val
+qtcore.Qt = type(
+    "Qt", (), {"WindowModal": 0, "ApplicationModal": 1, "QueuedConnection": 0}
+)
+sys.modules["PySide6.QtCore"] = qtcore
+
+qtwidgets = types.ModuleType("PySide6.QtWidgets")
 qtwidgets.LogoSplash = object
 qtwidgets.QWidget = object
 qtwidgets.QLabel = object
 qtwidgets.QVBoxLayout = object
-qtwidgets.QMessageBox = type('QMessageBox', (), {
-    'warning': staticmethod(lambda *a, **k: None),
-    'information': staticmethod(lambda *a, **k: None),
-})
-sys.modules['PySide6.QtWidgets'] = qtwidgets
-qtgui = types.ModuleType('PySide6.QtGui')
+qtwidgets.QMessageBox = type(
+    "QMessageBox",
+    (),
+    {
+        "warning": staticmethod(lambda *a, **k: None),
+        "information": staticmethod(lambda *a, **k: None),
+    },
+)
+sys.modules["PySide6.QtWidgets"] = qtwidgets
+qtgui = types.ModuleType("PySide6.QtGui")
 qtgui.QPixmap = object
-sys.modules['PySide6.QtGui'] = qtgui
+sys.modules["PySide6.QtGui"] = qtgui
 
 import importlib
 import gui.processing as processing  # noqa: E402
+
 processing = importlib.reload(processing)
 
 
@@ -116,22 +124,26 @@ def test_cancel_shutdown(monkeypatch):
     def run_command(cmd, capture=True):
         commands.append((cmd, capture))
 
-    dlg = DummyDialog()
-
-    monkeypatch.setattr(processing, "LogoSplash", lambda *a, **kw: dlg)
-    monkeypatch.setattr(processing, "QMetaObject", type("_", (), {"invokeMethod": lambda *a: a[0].setValue(a[3])}))
-    monkeypatch.setattr(processing, "Q_ARG", lambda *a: a[1])
     exec_instance = DummyExecutor()
-    monkeypatch.setattr(processing, "ThreadPoolExecutor", lambda *a, **kw: exec_instance)
+    monkeypatch.setattr(
+        processing, "ThreadPoolExecutor", lambda *a, **kw: exec_instance
+    )
     monkeypatch.setattr(processing, "as_completed", dummy_as_completed)
 
-    processing.process_files(jobs, max_workers=2, query_tracks=query_tracks,
-                             build_cmd=build_cmd, run_command=run_command,
-                             output_dir="out", wipe_all_flag=False)
+    processing.process_files(
+        jobs,
+        max_workers=2,
+        query_tracks=query_tracks,
+        build_cmd=build_cmd,
+        run_command=run_command,
+        output_dir="out",
+        wipe_all_flag=False,
+    )
 
-    assert len(commands) == 1
+    assert len(commands) == 2
     assert commands[0][1] is False
-    assert exec_instance.shutdown_called.get("cancel_futures") is True
+    assert commands[1][1] is False
+    assert exec_instance.shutdown_called == {"wait": True, "cancel_futures": False}
 
 
 def test_output_dir_created(monkeypatch, tmp_path):
@@ -147,17 +159,10 @@ def test_output_dir_created(monkeypatch, tmp_path):
     def run_command(cmd, capture=True):
         commands.append((cmd, capture))
 
-    dlg = DummyDialog()
-
-    monkeypatch.setattr(processing, "LogoSplash", lambda *a, **kw: dlg)
-    monkeypatch.setattr(
-        processing,
-        "QMetaObject",
-        type("_", (), {"invokeMethod": lambda *a: a[0].setValue(a[3])}),
-    )
-    monkeypatch.setattr(processing, "Q_ARG", lambda *a: a[1])
     exec_instance = DummyExecutor()
-    monkeypatch.setattr(processing, "ThreadPoolExecutor", lambda *a, **kw: exec_instance)
+    monkeypatch.setattr(
+        processing, "ThreadPoolExecutor", lambda *a, **kw: exec_instance
+    )
     monkeypatch.setattr(processing, "as_completed", dummy_as_completed)
 
     processing.process_files(


### PR DESCRIPTION
## Summary
- move `LogoSplash` widget to dedicated module
- drop splash during file processing
- display the splash when launching the application
- adjust tests for updated behaviour

## Testing
- `flake8`
- `black --check gui/widgets/logo_splash.py gui/processing.py mkv_cleaner.py tests/test_processing.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68439122c01483238032ea535639e5ff