### PR TITLE
Fix splash screen not appearing

### DIFF
--- a/gui/widgets/logo_splash.py
+++ b/gui/widgets/logo_splash.py
@@ -1,31 +1,19 @@
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QPixmap
-from PySide6.QtWidgets import QWidget, QLabel, QVBoxLayout
+from PySide6.QtWidgets import QSplashScreen
 from pathlib import Path
 
 
-class LogoSplash(QWidget):
+class LogoSplash(QSplashScreen):
     """Simple splash screen showing the application logo."""
 
     def __init__(self, parent=None):
-        super().__init__(
-            None, Qt.FramelessWindowHint | Qt.SplashScreen | Qt.WindowStaysOnTopHint
-        )
-        pixmap = QPixmap(
-            str(Path(__file__).resolve().parent.parent / "MKV-Cleaner_logo.png")
-        )
+        pixmap = QPixmap(str(Path(__file__).resolve().parent.parent / "MKV-Cleaner_logo.png"))
         if parent is not None:
             max_size = parent.size()
             if pixmap.width() > max_size.width() or pixmap.height() > max_size.height():
-                pixmap = pixmap.scaled(
-                    max_size, Qt.KeepAspectRatio, Qt.SmoothTransformation
-                )
-        label = QLabel(self)
-        label.setPixmap(pixmap)
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(label)
-        self.setFixedSize(pixmap.size())
+                pixmap = pixmap.scaled(max_size, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        super().__init__(pixmap, Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint)
         if parent is not None:
             center = parent.geometry().center()
             self.move(center.x() - self.width() // 2, center.y() - self.height() // 2)

--- a/mkv_cleaner.py
+++ b/mkv_cleaner.py
@@ -139,12 +139,12 @@ def main() -> None:
     # Show tooltips faster than the Qt default
     app.setStyle(FastToolTipStyle(app.style()))
     set_dynamic_modern_style(app)
+    splash = LogoSplash()
+    splash.show()
+    app.processEvents()
     win = MainWindow()
     win.show()
-    splash = LogoSplash(win)
-    splash.show()
-    splash.raise_()
-    QTimer.singleShot(1000, splash.close)
+    QTimer.singleShot(1000, lambda: splash.finish(win))
     sys.exit(app.exec())
 
 

--- a/tests/test_actions_logic.py
+++ b/tests/test_actions_logic.py
@@ -17,7 +17,7 @@ qtwidgets.QMessageBox = type('QMessageBox', (), {
 # Additional classes used by subtitle_preview imports
 for cls in (
     'QMainWindow', 'QTextEdit', 'QHBoxLayout', 'QVBoxLayout',
-    'QWidget', 'QPushButton', 'QLabel', 'LogoSplash'
+    'QWidget', 'QPushButton', 'QLabel', 'LogoSplash', 'QSplashScreen'
 ):
     setattr(qtwidgets, cls, object)
 sys.modules['PySide6.QtWidgets'] = qtwidgets

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -17,6 +17,7 @@ sys.modules["PySide6.QtCore"] = qtcore
 
 qtwidgets = types.ModuleType("PySide6.QtWidgets")
 qtwidgets.LogoSplash = object
+qtwidgets.QSplashScreen = object
 qtwidgets.QWidget = object
 qtwidgets.QLabel = object
 qtwidgets.QVBoxLayout = object


### PR DESCRIPTION
## Summary
- rework `LogoSplash` widget to use `QSplashScreen`
- show splash before main window so it becomes visible
- update tests to stub `QSplashScreen`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684392a696b88323a5e426af397005e3