### PR TITLE
Add fade animation to splash

### DIFF
--- a/gui/widgets/logo_splash.py
+++ b/gui/widgets/logo_splash.py
@@ -14,6 +14,12 @@ class LogoSplash(QSplashScreen):
         # root where ``MKV-Cleaner_logo.png`` is located.
         pixmap_path = Path(__file__).resolve().parents[2] / "MKV-Cleaner_logo.png"
         pixmap = QPixmap(str(pixmap_path))
+        pixmap = pixmap.scaled(
+            pixmap.width() // 2,
+            pixmap.height() // 2,
+            Qt.KeepAspectRatio,
+            Qt.SmoothTransformation,
+        )
         if parent is not None:
             max_size = parent.size()
             if pixmap.width() > max_size.width() or pixmap.height() > max_size.height():

--- a/mkv_cleaner.py
+++ b/mkv_cleaner.py
@@ -20,7 +20,7 @@ from gui.widgets.logo_splash import LogoSplash
 from pathlib import Path
 from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QFont, QFontDatabase
-from PySide6.QtCore import QSettings, QTimer
+from PySide6.QtCore import QSettings, QTimer, QPropertyAnimation, QAbstractAnimation
 
 
 def set_dynamic_modern_style(app: QApplication) -> None:
@@ -144,7 +144,18 @@ def main() -> None:
     app.processEvents()
     win = MainWindow()
     win.show()
-    QTimer.singleShot(1000, lambda: splash.finish(win))
+
+    def fade_and_finish():
+        anim = QPropertyAnimation(splash, b"windowOpacity")
+        anim.setDuration(500)
+        anim.setStartValue(1.0)
+        anim.setEndValue(0.0)
+        anim.finished.connect(lambda: splash.finish(win))
+        anim.start(QAbstractAnimation.DeleteWhenStopped)
+        # keep reference so it doesn't get garbage collected
+        splash._fade_anim = anim
+
+    QTimer.singleShot(1000, fade_and_finish)
     sys.exit(app.exec())
 
 


### PR DESCRIPTION
## Summary
- scale splash image to half-size
- fade splash screen out after 1 second

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843948cd9148323868537fb551cfa3b