### PR TITLE
Update tomli dep for Python <3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
     "pyside6",
-    "tomli",
+    "tomli; python_version < \"3.11\"",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add environment marker to only install `tomli` on Python <3.11

## Testing
- `pytest -q`
- `pip install . -vv` (ensured `tomli` was not installed for Python 3.11)


------
https://chatgpt.com/codex/tasks/task_e_684410ce83d083239033a9594e139b53