### PR TITLE
Add progress dialog to file processing

### DIFF
--- a/gui/processing.py
+++ b/gui/processing.py
@@ -1,9 +1,7 @@
-from PySide6.QtCore import QMetaObject, Q_ARG
-from PySide6.QtWidgets import QMessageBox
+from PySide6.QtCore import QMetaObject, Q_ARG, Qt
+from PySide6.QtWidgets import QMessageBox, QProgressDialog
 from pathlib import Path
 import logging
-
-from .widgets.logo_splash import LogoSplash
 
 logger = logging.getLogger(__name__)
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -22,6 +20,12 @@ def process_files(
     """Process multiple files in parallel and report progress/errors in the GUI."""
     if parent is not None:
         parent.setEnabled(False)
+
+    progress = QProgressDialog("Processing files...", "Cancel", 0, len(jobs), parent)
+    progress.setWindowModality(Qt.ApplicationModal)
+    progress.setMinimumDuration(0)
+    progress.show()
+    progress.activateWindow()
 
     errors = []
     import threading
@@ -65,11 +69,22 @@ def process_files(
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = [executor.submit(process_one, src, tracks) for src, tracks in jobs]
+        processed = 0
         for fut in as_completed(futures):
             fut.result()
+            processed += 1
+            progress.setValue(processed)
+            if progress.wasCanceled():
+                executor.shutdown(wait=False, cancel_futures=True)
+                break
+
+    progress.close()
 
     if parent is not None:
         parent.setEnabled(True)
+
+    if progress.wasCanceled():
+        return
 
     if errors:
         msg = "\n".join([f"{f}: {err}" for f, err in errors])

--- a/tests/test_actions_logic.py
+++ b/tests/test_actions_logic.py
@@ -20,6 +20,7 @@ for cls in (
     'QWidget', 'QPushButton', 'QLabel', 'LogoSplash', 'QSplashScreen'
 ):
     setattr(qtwidgets, cls, object)
+qtwidgets.QProgressDialog = object
 sys.modules['PySide6.QtWidgets'] = qtwidgets
 qtgui = types.ModuleType('PySide6.QtGui')
 qtgui.QPixmap = object

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -21,6 +21,7 @@ qtwidgets.QSplashScreen = object
 qtwidgets.QWidget = object
 qtwidgets.QLabel = object
 qtwidgets.QVBoxLayout = object
+qtwidgets.QProgressDialog = object
 qtwidgets.QMessageBox = type(
     "QMessageBox",
     (),
@@ -44,6 +45,7 @@ class DummyDialog:
     def __init__(self):
         self._val = 0
         self._canceled = False
+        self.closed = False
 
     def setWindowModality(self, *a):
         pass
@@ -53,20 +55,23 @@ class DummyDialog:
 
     def setValue(self, val):
         self._val = val
-        if val >= 1:
-            self._canceled = True
 
     def wasCanceled(self):
         return self._canceled
 
     def close(self):
-        pass
+        self.closed = True
 
     def show(self):
         pass
 
     def activateWindow(self):
         pass
+
+    def cancel(self):
+        self._canceled = True
+
+processing.QProgressDialog = lambda *a, **kw: DummyDialog()
 
 
 class DummyExecutor:
@@ -178,3 +183,38 @@ def test_output_dir_created(monkeypatch, tmp_path):
 
     assert (tmp_path / "out" / "sub").is_dir()
     assert commands and commands[0][1] is False
+
+
+def test_progress_updates(monkeypatch):
+    jobs = [(Path("a"), []), (Path("b"), []), (Path("c"), [])]
+
+    def query_tracks(src):
+        return []
+
+    def build_cmd(src, dst, tracks, wipe_forced=False, wipe_all=False):
+        return ["cmd", str(src), str(dst)]
+
+    def run_command(cmd, capture=True):
+        pass
+
+    exec_instance = DummyExecutor()
+    monkeypatch.setattr(
+        processing, "ThreadPoolExecutor", lambda *a, **kw: exec_instance
+    )
+    monkeypatch.setattr(processing, "as_completed", dummy_as_completed)
+
+    progress = DummyDialog()
+    monkeypatch.setattr(processing, "QProgressDialog", lambda *a, **kw: progress)
+
+    processing.process_files(
+        jobs,
+        max_workers=2,
+        query_tracks=query_tracks,
+        build_cmd=build_cmd,
+        run_command=run_command,
+        output_dir="out",
+        wipe_all_flag=False,
+    )
+
+    assert progress._val == len(jobs)
+    assert progress.closed is True


### PR DESCRIPTION
## Summary
- show a QProgressDialog while cleaning files
- update PySide6 stubs for the progress dialog
- test that progress updates are emitted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68442f0a122c83239b811bcc3c8bf9d4