### PR TITLE
Add module and class docstrings in GUI widgets

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,1 +1,1 @@
-
+"""PySide6 based user interface for the MKV Cleaner application."""

--- a/gui/actions_logic.py
+++ b/gui/actions_logic.py
@@ -1,3 +1,5 @@
+"""Mixin implementing handlers for the action bar buttons."""
+
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QMessageBox
 from core.tracks import query_tracks, build_cmd, run_command

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -1,3 +1,5 @@
+"""Small dialog windows used throughout the GUI."""
+
 from PySide6.QtWidgets import (
     QDialog,
     QFormLayout,
@@ -16,6 +18,7 @@ from PySide6.QtGui import QKeySequence
 
 
 class HotkeysDialog(QDialog):
+    """Display a list of configured keyboard shortcuts."""
     def __init__(self, hotkeys: dict[str, list[str]], parent=None):
         super().__init__(parent)
         self.setWindowTitle("Hotkeys")
@@ -28,6 +31,7 @@ class HotkeysDialog(QDialog):
         layout.addRow(btn)
 
 class PreferencesDialog(QDialog):
+    """Dialog for editing application preferences like backend and paths."""
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Preferences")

--- a/gui/group_logic.py
+++ b/gui/group_logic.py
@@ -1,3 +1,5 @@
+"""Mixin containing logic for grouping and navigating multiple files."""
+
 from pathlib import Path
 import copy
 from core.tracks import query_tracks

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,3 +1,5 @@
+"""Main application window assembling all GUI widgets and logic."""
+
 from PySide6.QtWidgets import (
     QMainWindow,
     QVBoxLayout,

--- a/gui/models.py
+++ b/gui/models.py
@@ -1,3 +1,5 @@
+"""Qt table models representing MKV track information."""
+
 from PySide6.QtCore import QAbstractTableModel, Qt, QModelIndex
 from PySide6.QtGui import QColor
 from core.tracks import Track

--- a/gui/processing.py
+++ b/gui/processing.py
@@ -1,3 +1,5 @@
+"""Functions for running file processing jobs with a progress dialog."""
+
 from PySide6.QtCore import QMetaObject, Q_ARG
 from PySide6.QtWidgets import QMessageBox
 from pathlib import Path

--- a/gui/settings_logic.py
+++ b/gui/settings_logic.py
@@ -1,3 +1,5 @@
+"""Mixin for loading, storing and editing application preferences."""
+
 from PySide6.QtCore import QSettings
 from gui.dialogs import PreferencesDialog
 from core.config import load_config, AppConfig

--- a/gui/subtitle_preview.py
+++ b/gui/subtitle_preview.py
@@ -1,3 +1,5 @@
+"""Utilities and window for previewing subtitles extracted from files."""
+
 from PySide6.QtWidgets import (
     QMainWindow,
     QTextEdit,

--- a/gui/table_logic.py
+++ b/gui/table_logic.py
@@ -1,3 +1,5 @@
+"""Mixin with helper methods for interacting with the track table."""
+
 from PySide6.QtCore import Qt
 
 class TableLogic:

--- a/gui/widgets/action_bar.py
+++ b/gui/widgets/action_bar.py
@@ -1,3 +1,5 @@
+"""Widget containing the main action buttons used by the application."""
+
 from PySide6.QtWidgets import QWidget, QHBoxLayout, QPushButton
 from PySide6.QtCore import Qt
 
@@ -5,6 +7,7 @@ from .fade_disabled import apply_fade_on_disable
 
 
 class ActionBar(QWidget):
+    """Horizontal bar exposing file and processing actions as buttons."""
     def __init__(self, parent=None):
         super().__init__(parent)
         self._setup_ui()

--- a/gui/widgets/fade_disabled.py
+++ b/gui/widgets/fade_disabled.py
@@ -1,3 +1,5 @@
+"""Utility to fade widgets whenever they become disabled."""
+
 try:
     from PySide6.QtWidgets import QGraphicsOpacityEffect
     from PySide6.QtCore import QObject, QEvent

--- a/gui/widgets/fast_tooltip_style.py
+++ b/gui/widgets/fast_tooltip_style.py
@@ -1,3 +1,5 @@
+"""Proxy style that displays tooltips almost immediately."""
+
 from PySide6.QtWidgets import QProxyStyle, QStyle
 
 

--- a/gui/widgets/file_list.py
+++ b/gui/widgets/file_list.py
@@ -1,3 +1,5 @@
+"""List widget that displays input files for the selected group."""
+
 from PySide6.QtWidgets import QListWidget, QListWidgetItem, QListView
 from PySide6.QtCore import Qt
 import re

--- a/gui/widgets/flag_delegate.py
+++ b/gui/widgets/flag_delegate.py
@@ -1,3 +1,5 @@
+"""Item delegate that paints flag icons for forced/default states."""
+
 from PySide6.QtWidgets import QStyledItemDelegate, QStyleOptionViewItem, QStyle, QApplication
 from PySide6.QtCore import Qt, QRect
 

--- a/gui/widgets/group_bar.py
+++ b/gui/widgets/group_bar.py
@@ -1,3 +1,5 @@
+"""Top bar widget for navigating and processing groups of files."""
+
 from PySide6.QtWidgets import (
     QWidget,
     QHBoxLayout,
@@ -13,6 +15,7 @@ from .fade_disabled import apply_fade_on_disable
 
 
 class GroupBar(QWidget):
+    """Navigation bar listing groups and exposing processing controls."""
     preferencesClicked = Signal()
     backendChanged = Signal(str)
     prevClicked = Signal()

--- a/gui/widgets/keep_toggle_delegate.py
+++ b/gui/widgets/keep_toggle_delegate.py
@@ -1,3 +1,5 @@
+"""Delegate drawing a toggle button for keeping or removing a track."""
+
 from PySide6.QtWidgets import QStyledItemDelegate, QStyle, QStyleOptionViewItem, QApplication
 from PySide6.QtGui import QColor
 from PySide6.QtCore import Qt, QEvent

--- a/gui/widgets/logo_splash.py
+++ b/gui/widgets/logo_splash.py
@@ -1,3 +1,5 @@
+"""Splash screen displaying the application logo during start-up."""
+
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import QSplashScreen

--- a/gui/widgets/no_focus_delegate.py
+++ b/gui/widgets/no_focus_delegate.py
@@ -1,3 +1,5 @@
+"""Item delegate that hides focus highlighting for cleaner look."""
+
 from PySide6.QtWidgets import (
     QStyledItemDelegate,
     QStyleOptionViewItem,

--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -1,3 +1,4 @@
+"""Table view displaying track metadata with custom delegates."""
 
 from PySide6.QtWidgets import (
     QTableView,
@@ -12,6 +13,7 @@ from .flag_delegate import FlagDelegate
 from .no_focus_delegate import NoFocusDelegate
 
 class TrackTable(QTableView):
+    """Table listing tracks with delegates for editing flags and states."""
     def __init__(self, parent=None):
         super().__init__(parent)
         self.table_model = TrackTableModel()


### PR DESCRIPTION
## Summary
- document GUI package modules
- add concise descriptions to GUI widget classes like `ActionBar`, `GroupBar` and `TrackTable`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68442efb47408323b6a77923b9632460