### PR TITLE
Fix overwrite prompt deadlock

### DIFF
--- a/gui/processing.py
+++ b/gui/processing.py
@@ -72,6 +72,16 @@ def process_files(
 
             helper = _DialogHelper()
 
+            if (
+                parent is not None
+                and hasattr(helper, "moveToThread")
+                and hasattr(parent, "thread")
+            ):
+                try:
+                    helper.moveToThread(parent.thread())
+                except Exception:
+                    pass
+
             try:
                 res = QMetaObject.invokeMethod(
                     helper, "ask", Qt.BlockingQueuedConnection, Q_ARG(str, msg)


### PR DESCRIPTION
## Summary
- ensure overwrite dialog helper runs in the parent UI thread to avoid deadlocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684437753aa483239c932483745195d0