### PR TITLE
Add overwrite flag for ffmpeg

### DIFF
--- a/core/tracks.py
+++ b/core/tracks.py
@@ -192,6 +192,8 @@ def _build_cmd_ffmpeg(
 ) -> list[str]:
     cmd: list[str] = [
         cfg.ffmpeg_cmd,
+        # Overwrite existing output without asking
+        "-y",
         "-loglevel",
         "error",
         "-i",

--- a/tests/test_tracks.py
+++ b/tests/test_tracks.py
@@ -51,6 +51,7 @@ def test_build_cmd_flags(defaults):
     cmd = build_cmd(src, dst, tracks, defaults, wipe_forced=True, wipe_all=False)
     assert cmd == [
         "ffmpeg",
+        "-y",
         "-loglevel",
         "error",
         "-i",
@@ -112,6 +113,7 @@ def test_build_cmd_wipe_all(defaults):
     cmd = build_cmd(src, dst, tracks, defaults, wipe_forced=False, wipe_all=True)
     assert cmd == [
         "ffmpeg",
+        "-y",
         "-loglevel",
         "error",
         "-i",
@@ -172,6 +174,7 @@ def test_build_cmd_forced_default_ffmpeg(defaults):
     cmd = build_cmd(src, dst, tracks, defaults, wipe_forced=False, wipe_all=False)
     assert cmd == [
         "ffmpeg",
+        "-y",
         "-loglevel",
         "error",
         "-i",


### PR DESCRIPTION
## Summary
- ensure ffmpeg overwrites output files without prompting
- keep mkvtoolnix behavior unchanged
- clarify purpose with inline comment

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68443b1e352083238e5282915213bbe0