### PR TITLE
Implement progress dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ are distributed alongside the bundle.
     - wipe all subtitles if desired
     - the status bar shows which track became default or forced
 5. Use **Process Group** or **Process All** to create cleaned files in the output directory (by default `cleaned/`).
+   A progress dialog shows how many files have finished.
 
 Paths to the command line tools, the output directory and the preferred backend (MKVToolNix or FFmpeg) can be configured via the Preferences dialog (⚙️ icon).
 

--- a/tests/test_actions_logic.py
+++ b/tests/test_actions_logic.py
@@ -20,7 +20,8 @@ qtwidgets.QMessageBox = type('QMessageBox', (), {
 # Additional classes used by subtitle_preview imports
 for cls in (
     'QMainWindow', 'QTextEdit', 'QHBoxLayout', 'QVBoxLayout',
-    'QWidget', 'QPushButton', 'QLabel', 'LogoSplash', 'QSplashScreen'
+    'QWidget', 'QPushButton', 'QLabel', 'LogoSplash',
+    'QSplashScreen', 'QProgressDialog'
 ):
     setattr(qtwidgets, cls, object)
 sys.modules['PySide6.QtWidgets'] = qtwidgets

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -21,6 +21,20 @@ qtwidgets.QSplashScreen = object
 qtwidgets.QWidget = object
 qtwidgets.QLabel = object
 qtwidgets.QVBoxLayout = object
+qtwidgets.QProgressDialog = type(
+    "QProgressDialog",
+    (),
+    {
+        "__init__": lambda self, *a, **k: None,
+        "setWindowModality": lambda *a, **k: None,
+        "setMinimumDuration": lambda *a, **k: None,
+        "setValue": lambda *a, **k: None,
+        "wasCanceled": lambda *a, **k: False,
+        "close": lambda *a, **k: None,
+        "show": lambda *a, **k: None,
+        "activateWindow": lambda *a, **k: None,
+    },
+)
 qtwidgets.QMessageBox = type(
     "QMessageBox",
     (),


### PR DESCRIPTION
## Summary
- add a QProgressDialog to show progress when processing files
- remove unused LogoSplash import
- mention progress dialog in README
- stub QProgressDialog in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443fe43cc48323ad39fb8895f26be8