### PR TITLE
Remove unused progress dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ are distributed alongside the bundle.
     - wipe all subtitles if desired
     - the status bar shows which track became default or forced
 5. Use **Process Group** or **Process All** to create cleaned files in the output directory (by default `cleaned/`).
-   A progress dialog shows how many files have finished.
 
 Paths to the command line tools, the output directory and the preferred backend (MKVToolNix or FFmpeg) can be configured via the Preferences dialog (⚙️ icon).
 

--- a/tests/test_actions_logic.py
+++ b/tests/test_actions_logic.py
@@ -21,7 +21,7 @@ qtwidgets.QMessageBox = type('QMessageBox', (), {
 for cls in (
     'QMainWindow', 'QTextEdit', 'QHBoxLayout', 'QVBoxLayout',
     'QWidget', 'QPushButton', 'QLabel', 'LogoSplash',
-    'QSplashScreen', 'QProgressDialog'
+    'QSplashScreen'
 ):
     setattr(qtwidgets, cls, object)
 sys.modules['PySide6.QtWidgets'] = qtwidgets

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -21,20 +21,6 @@ qtwidgets.QSplashScreen = object
 qtwidgets.QWidget = object
 qtwidgets.QLabel = object
 qtwidgets.QVBoxLayout = object
-qtwidgets.QProgressDialog = type(
-    "QProgressDialog",
-    (),
-    {
-        "__init__": lambda self, *a, **k: None,
-        "setWindowModality": lambda *a, **k: None,
-        "setMinimumDuration": lambda *a, **k: None,
-        "setValue": lambda *a, **k: None,
-        "wasCanceled": lambda *a, **k: False,
-        "close": lambda *a, **k: None,
-        "show": lambda *a, **k: None,
-        "activateWindow": lambda *a, **k: None,
-    },
-)
 qtwidgets.QMessageBox = type(
     "QMessageBox",
     (),
@@ -56,34 +42,6 @@ import gui.processing as processing  # noqa: E402
 
 processing = importlib.reload(processing)
 
-
-class DummyDialog:
-    def __init__(self):
-        self._val = 0
-        self._canceled = False
-
-    def setWindowModality(self, *a):
-        pass
-
-    def setMinimumDuration(self, *a):
-        pass
-
-    def setValue(self, val):
-        self._val = val
-        if val >= 1:
-            self._canceled = True
-
-    def wasCanceled(self):
-        return self._canceled
-
-    def close(self):
-        pass
-
-    def show(self):
-        pass
-
-    def activateWindow(self):
-        pass
 
 
 class DummyExecutor:


### PR DESCRIPTION
## Summary
- drop progress dialog from the processing pipeline
- clean up related tests and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684441879bcc8323b4bbf5e74bb38f6d