### PR TITLE
Use Noto emoji arrows

### DIFF
--- a/gui/subtitle_preview.py
+++ b/gui/subtitle_preview.py
@@ -176,10 +176,10 @@ class SubtitlePreviewWindow(QMainWindow):
 
         self.txt = QTextEdit(readOnly=True)
         nav = QHBoxLayout()
-        self.prev = QPushButton("◀ Prev")
+        self.prev = QPushButton("◀️ Prev")
         apply_fade_on_disable(self.prev)
         self.prev.setToolTip("Show subtitles from the previous file in the group.")
-        self.nxt = QPushButton("Next ▶")
+        self.nxt = QPushButton("Next ▶️")
         apply_fade_on_disable(self.nxt)
         self.nxt.setToolTip("Show subtitles from the next file in the group.")
         nav.addWidget(self.prev)

--- a/gui/widgets/group_bar.py
+++ b/gui/widgets/group_bar.py
@@ -84,8 +84,8 @@ class GroupBar(QWidget):
         self.btn_groups.clicked.connect(self._open_drawer)
         self.layout.addWidget(self.btn_groups, alignment=Qt.AlignVCenter)
 
-        # Use plain arrow characters so they are visible without color emoji support
-        self.btn_prev = QPushButton("⬅")
+        # Use emoji arrows now that we bundle NotoColorEmoji for consistent color
+        self.btn_prev = QPushButton("⬅️")
         self.btn_prev.setCheckable(False)
         self.btn_prev.setMinimumSize(QSize(32, 40))
         self.btn_prev.setMaximumSize(QSize(32, 44))
@@ -108,7 +108,7 @@ class GroupBar(QWidget):
         self.group_btns_layout.setContentsMargins(0, 0, 0, 0)
         self.group_btns_layout.setSpacing(6)
 
-        self.btn_next = QPushButton("➡")
+        self.btn_next = QPushButton("➡️")
         self.btn_next.setCheckable(False)
         self.btn_next.setMinimumSize(QSize(32, 40))
         self.btn_next.setMaximumSize(QSize(32, 44))


### PR DESCRIPTION
## Summary
- use emoji arrows in GroupBar buttons
- use emoji arrows in subtitle preview navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844539b418c832392ea411cffcea097