### PR TITLE
Highlight current group in drawer

### DIFF
--- a/gui/widgets/group_bar.py
+++ b/gui/widgets/group_bar.py
@@ -41,6 +41,8 @@ class GroupDrawer(QDialog):
             b = QPushButton(btn.text(), self)
             b.setFixedSize(btn.size())
             b.setStyleSheet(btn.styleSheet())
+            b.setCheckable(True)
+            b.setChecked(btn.isChecked())
             b.clicked.connect(lambda checked=False, i=idx: self._choose(i))
             row, col = divmod(idx, 4)
             layout.addWidget(b, row, col)


### PR DESCRIPTION
## Summary
- mark the current group button as checked in the group drawer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445ee76e4c8323bb3596f258d468db