### PR TITLE
Improve run_command error logging

### DIFF
--- a/core/tracks.py
+++ b/core/tracks.py
@@ -54,7 +54,8 @@ def run_command(cmd: list[str], capture: bool = True) -> subprocess.CompletedPro
         logger.error(msg)
         raise CommandNotFoundError(msg) from exc
     except subprocess.CalledProcessError as exc:
-        logger.error("Command failed: %s\n%s", exc, exc.stderr)
+        err_msg = exc.stderr or ""
+        logger.error("Command failed: %s\n%s", exc, err_msg)
         raise
 
 def query_tracks(source: Path, cfg: AppConfig) -> List[Track]:

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -45,3 +45,14 @@ def test_run_command_no_capture(monkeypatch):
     tracks.run_command(["echo", "hi"], capture=False)
     assert "capture_output" not in called
 
+
+def test_run_command_error_no_stderr(monkeypatch, caplog):
+    def fake_run(cmd, **kw):
+        raise subprocess.CalledProcessError(1, cmd, stderr=None)
+
+    monkeypatch.setattr(tracks.subprocess, "run", fake_run)
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(subprocess.CalledProcessError):
+        tracks.run_command(["bad"], capture=False)
+    assert "Command failed" in caplog.text
+


### PR DESCRIPTION
## Summary
- ensure run_command logs CalledProcessError safely even when stderr is absent
- test run_command with capture=False raises CalledProcessError and logs correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446c800f5083238dea595984101cb6