### PR TITLE
chore: fix whitespace in processing module

### DIFF
--- a/gui/processing.py
+++ b/gui/processing.py
@@ -41,7 +41,7 @@ def process_files(
                 return
 
         parent.setEnabled(False)
-    
+
     errors = []
     import threading
 


### PR DESCRIPTION
## Summary
- clean up whitespace line in processing

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6844730573a88323bfdfc9d1d88cfdf2