### PR TITLE
Fix wipe all toggle not resetting after deleting last group

### DIFF
--- a/gui/group_logic.py
+++ b/gui/group_logic.py
@@ -189,3 +189,9 @@ class GroupLogic:
             self.group_bar.update_nav_buttons(idx_cur)
 
         self._update_process_buttons()
+
+        # Reset wipe all toggle if no group is selected
+        if self.current_sig is None:
+            btn = getattr(getattr(self, "action_bar", None), "btn_wipe_all", None)
+            if btn is not None:
+                btn.setChecked(False)

--- a/tests/test_group_logic.py
+++ b/tests/test_group_logic.py
@@ -134,3 +134,38 @@ def test_add_files_no_duplicates(monkeypatch):
     sig = ";".join(t.signature() for t in tracks)
     assert len(logic.file_groups[sig]) == 1
     assert len(logic.group_bar.group_buttons) == 1
+
+
+class DummyWipeButton:
+    def __init__(self):
+        self.checked = False
+
+    def setChecked(self, val):
+        self.checked = val
+
+    def isChecked(self):
+        return self.checked
+
+
+class DummyActionBar:
+    def __init__(self):
+        self.btn_wipe_all = DummyWipeButton()
+
+
+def test_delete_group_resets_wipe_all():
+    logic = GroupLogic()
+    logic.group_bar = DummyGroupBar()
+    logic.track_table = DummyTrackTable()
+    logic.action_bar = DummyActionBar()
+    logic._setup_group_logic()
+
+    logic.groups["sig1"] = []
+    logic.file_groups["sig1"] = ["f1"]
+    logic.current_sig = "sig1"
+    logic.group_bar.add_group_button("sig1")
+
+    logic.action_bar.btn_wipe_all.setChecked(True)
+
+    logic._empty_current_group()
+
+    assert logic.action_bar.btn_wipe_all.isChecked() is False


### PR DESCRIPTION
## Summary
- reset the "Wipe All Subs" toggle when no group remains
- add regression test to ensure the button clears

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846af3859748323895196359f526639