### PR TITLE
Ensure stderr captured on failing uncaptured commands

### DIFF
--- a/core/tracks.py
+++ b/core/tracks.py
@@ -46,9 +46,10 @@ def run_command(cmd: list[str], capture: bool = True) -> subprocess.CompletedPro
 
     logger.debug("Running: %s", " ".join(cmd))
     try:
-        if capture:
-            return subprocess.run(cmd, check=True, capture_output=True, text=True)
-        return subprocess.run(cmd, check=True)
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        if not capture:
+            result.stdout = ""
+        return result
     except FileNotFoundError as exc:
         msg = f"{cmd[0]} not found on PATH"
         logger.error(msg)


### PR DESCRIPTION
## Summary
- always capture subprocess output in `run_command`
- discard stdout when `capture=False`
- update tests for new semantics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b28fcd788323a0e5378af1b16f79