### PR TITLE
Use idx in Track signature, add grouping test

### DIFF
--- a/core/tracks.py
+++ b/core/tracks.py
@@ -33,7 +33,7 @@ class Track:
         """Return a string uniquely identifying the track."""
 
         return (
-            f"{self.tid}-{self.type}-{self.codec}-"
+            f"{self.idx}-{self.type}-{self.codec}-"
             f"{self.language}-{'F' if self.forced else ''}-{self.name}"
         )
 


### PR DESCRIPTION
## Summary
- use track idx when computing Track.signature to ignore mkvmerge track ids
- add test verifying grouping logic groups files with same layout but different tids

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b4fc5654832398b941e1543b0d4e