### PR TITLE
Validate alphabetic country codes for flags

### DIFF
--- a/core/flags.py
+++ b/core/flags.py
@@ -13,6 +13,7 @@ _LANG_TO_COUNTRY = {
     # German
     "de": "DE",
     "deu": "DE",
+    "ger": "DE",
     # French
     "fr": "FR",
     "fra": "FR",
@@ -117,12 +118,62 @@ _LANG_TO_COUNTRY = {
     "tgl": "PH",
 }
 
+# Mapping from ISO 3166-1 alpha-3 codes to alpha-2 codes for basic coverage
+_COUNTRY_ALPHA3_TO_ALPHA2 = {
+    "GBR": "GB",
+    "ESP": "ES",
+    "DEU": "DE",
+    "FRA": "FR",
+    "ITA": "IT",
+    "PRT": "PT",
+    "RUS": "RU",
+    "JPN": "JP",
+    "CHN": "CN",
+    "IRN": "IR",
+    "SAU": "SA",
+    "NLD": "NL",
+    "POL": "PL",
+    "TUR": "TR",
+    "KOR": "KR",
+    "IND": "IN",
+    "VNM": "VN",
+    "SWE": "SE",
+    "GRC": "GR",
+    "ISR": "IL",
+    "THA": "TH",
+    "DNK": "DK",
+    "FIN": "FI",
+    "HUN": "HU",
+    "NOR": "NO",
+    "ROU": "RO",
+    "BGR": "BG",
+    "CZE": "CZ",
+    "SVK": "SK",
+    "HRV": "HR",
+    "UKR": "UA",
+    "IDN": "ID",
+    "MYS": "MY",
+    "PHL": "PH",
+    "USA": "US",
+    "CAN": "CA",
+}
+
 
 def _country_code_to_flag(cc: str) -> str:
-    """Convert a 2-letter country code to an emoji flag."""
-    if len(cc) != 2:
+    """Convert a country code (alpha-2 or alpha-3) to an emoji flag.
+
+    Invalid or unknown codes yield an empty string.
+    """
+    if not cc or not cc.isalpha():
         return ""
-    return chr(127397 + ord(cc[0].upper())) + chr(127397 + ord(cc[1].upper()))
+    cc = cc.upper()
+    if len(cc) == 3:
+        cc = _COUNTRY_ALPHA3_TO_ALPHA2.get(cc, "")
+        if not cc:
+            return ""
+    elif len(cc) != 2:
+        return ""
+    return chr(127397 + ord(cc[0])) + chr(127397 + ord(cc[1]))
 
 
 def lang_to_flag(lang: str) -> str:
@@ -132,17 +183,18 @@ def lang_to_flag(lang: str) -> str:
     lang = lang.lower()
     cc = _LANG_TO_COUNTRY.get(lang)
     if not cc:
-        if '-' in lang or '_' in lang:
-            country = lang.split('-')[1] if '-' in lang else lang.split('_')[1]
+        if "-" in lang or "_" in lang:
+            country = lang.split("-")[1] if "-" in lang else lang.split("_")[1]
             if len(country) == 2:
                 cc = country.upper()
     if not cc:
         import locale
-        loc = locale.getdefaultlocale()[0] or ''
+
+        loc = locale.getdefaultlocale()[0] or ""
         if not loc:
-            loc = locale.getlocale()[0] or ''
-        if loc and ('_' in loc or '-' in loc):
-            country = loc.split('_')[1] if '_' in loc else loc.split('-')[1]
+            loc = locale.getlocale()[0] or ""
+        if loc and ("_" in loc or "-" in loc):
+            country = loc.split("_")[1] if "_" in loc else loc.split("-")[1]
             if len(country) == 2:
                 cc = country.upper()
     return _country_code_to_flag(cc) if cc else ""

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,29 +1,53 @@
-from core.flags import lang_to_flag
+from core.flags import lang_to_flag, _LANG_TO_COUNTRY, _country_code_to_flag
 
 
 def test_lang_to_flag_known_codes():
-    assert lang_to_flag('eng') == lang_to_flag('en') == '🇬🇧'
-    assert lang_to_flag('fra') == lang_to_flag('fre') == lang_to_flag('fr') == '🇫🇷'
-    assert lang_to_flag('spa') == '🇪🇸'
-    assert lang_to_flag('deu') == '🇩🇪'
-    assert lang_to_flag('fas') == lang_to_flag('fa') == '🇮🇷'
-    assert lang_to_flag('pol') == '🇵🇱'
-    assert lang_to_flag('dan') == lang_to_flag('da') == '🇩🇰'
-    assert lang_to_flag('ces') == lang_to_flag('cs') == '🇨🇿'
-    assert lang_to_flag('hrv') == lang_to_flag('hr') == '🇭🇷'
+    assert lang_to_flag("eng") == lang_to_flag("en") == "🇬🇧"
+    assert lang_to_flag("fra") == lang_to_flag("fre") == lang_to_flag("fr") == "🇫🇷"
+    assert lang_to_flag("spa") == "🇪🇸"
+    assert lang_to_flag("deu") == "🇩🇪"
+    assert lang_to_flag("ger") == "🇩🇪"
+    assert lang_to_flag("fas") == lang_to_flag("fa") == "🇮🇷"
+    assert lang_to_flag("pol") == "🇵🇱"
+    assert lang_to_flag("dan") == lang_to_flag("da") == "🇩🇰"
+    assert lang_to_flag("ces") == lang_to_flag("cs") == "🇨🇿"
+    assert lang_to_flag("hrv") == lang_to_flag("hr") == "🇭🇷"
 
 
 def test_lang_to_flag_unknown(monkeypatch):
     import locale
 
-    monkeypatch.setattr(locale, 'getdefaultlocale', lambda: (None, None))
-    monkeypatch.setattr(locale, 'getlocale', lambda: (None, None))
-    assert lang_to_flag('xxx') == ''
+    monkeypatch.setattr(locale, "getdefaultlocale", lambda: (None, None))
+    monkeypatch.setattr(locale, "getlocale", lambda: (None, None))
+    assert lang_to_flag("xxx") == ""
+
+
+def test_lang_to_flag_invalid_inputs(monkeypatch):
+    """Ensure invalid language strings do not raise and return an empty flag."""
+    import locale
+
+    monkeypatch.setattr(locale, "getdefaultlocale", lambda: (None, None))
+    monkeypatch.setattr(locale, "getlocale", lambda: (None, None))
+    assert lang_to_flag("12") == ""
+    assert lang_to_flag("@!") == ""
+
+
+def test_country_code_to_flag_alpha3():
+    assert _country_code_to_flag("USA") == "🇺🇸"
+    assert _country_code_to_flag("DEU") == "🇩🇪"
+    assert _country_code_to_flag("XXX") == ""
 
 
 def test_lang_to_flag_locale_fallback(monkeypatch):
     import locale
 
-    monkeypatch.setattr(locale, 'getdefaultlocale', lambda: ('fr_FR', 'UTF-8'))
-    monkeypatch.setattr(locale, 'getlocale', lambda: ('fr_FR', 'UTF-8'))
-    assert lang_to_flag('xxx') == '🇫🇷'
+    monkeypatch.setattr(locale, "getdefaultlocale", lambda: ("fr_FR", "UTF-8"))
+    monkeypatch.setattr(locale, "getlocale", lambda: ("fr_FR", "UTF-8"))
+    assert lang_to_flag("xxx") == "🇫🇷"
+
+
+def test_all_language_mappings():
+    """Ensure every entry in the mapping yields the correct flag."""
+    for code, country in _LANG_TO_COUNTRY.items():
+        expected = _country_code_to_flag(country)
+        assert lang_to_flag(code) == expected


### PR DESCRIPTION
## Summary
- guard against invalid country codes in `_country_code_to_flag`
- add `'ger'` mapping for Germany
- verify every mapping returns the correct flag
- handle ISO alpha-3 country codes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846b28299508323b14d3e92902d541d