### PR TITLE
Fix drag toggle interfering with clicks

### DIFF
--- a/gui/widgets/track_table.py
+++ b/gui/widgets/track_table.py
@@ -106,10 +106,10 @@ class TrackTable(QTableView):
         self.setFixedHeight(total)
 
     def mouseReleaseEvent(self, event):
+        super().mouseReleaseEvent(event)
         delegate = self.itemDelegateForColumn(0)
         if hasattr(delegate, "reset_drag"):
             delegate.reset_drag()
-        super().mouseReleaseEvent(event)
 
     def leaveEvent(self, event):
         delegate = self.itemDelegateForColumn(0)

--- a/tests/test_keep_toggle_delegate.py
+++ b/tests/test_keep_toggle_delegate.py
@@ -77,3 +77,18 @@ def test_reset_drag_clears_state():
     delegate.reset_drag()
     assert delegate._dragging is False
     assert delegate._drag_state is None
+
+
+def test_click_toggle_updates_state():
+    delegate = KeepToggleDelegate()
+    model = DummyModel()
+    idx = DummyIndex(model)
+    opt = DummyOption()
+
+    delegate.editorEvent(DummyEvent(QEvent.MouseButtonPress), model, opt, idx)
+    delegate.editorEvent(DummyEvent(QEvent.MouseButtonRelease), model, opt, idx)
+    delegate.reset_drag()
+
+    assert model.state == Qt.Unchecked
+
+


### PR DESCRIPTION
## Summary
- fix click toggling by resetting drag state after release
- add regression test for keep toggle delegate

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d1e2daf083238edf25383afa7bb5