### PR TITLE
Improve documentation and refactor config

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -1,8 +1,9 @@
+"""Configuration helpers and executable path setup."""
+
 from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Dict
 from dataclasses import dataclass
 import json
 import os
@@ -17,17 +18,17 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for older versions
 
 if getattr(sys, 'frozen', False):  # Running from PyInstaller bundle
     bindir = Path(getattr(sys, '_MEIPASS', Path(sys.executable).parent))
-    ext = '.exe' if os.name == 'nt' else ''
-    MKVMERGE = str(bindir / f"mkvmerge{ext}")
-    MKVEXTRACT = str(bindir / f"mkvextract{ext}")
-    FFMPEG = str(bindir / f"ffmpeg{ext}")
-    FFPROBE = str(bindir / f"ffprobe{ext}")
+    EXT = '.exe' if os.name == 'nt' else ''
+    MKVMERGE = str(bindir / f"mkvmerge{EXT}")
+    MKVEXTRACT = str(bindir / f"mkvextract{EXT}")
+    FFMPEG = str(bindir / f"ffmpeg{EXT}")
+    FFPROBE = str(bindir / f"ffprobe{EXT}")
 else:
-    ext = '.exe' if os.name == 'nt' else ''
-    MKVMERGE = f"mkvmerge{ext}"
-    MKVEXTRACT = f"mkvextract{ext}"
-    FFMPEG = f"ffmpeg{ext}"
-    FFPROBE = f"ffprobe{ext}"
+    EXT = '.exe' if os.name == 'nt' else ''
+    MKVMERGE = f"mkvmerge{EXT}"
+    MKVEXTRACT = f"mkvextract{EXT}"
+    FFMPEG = f"ffmpeg{EXT}"
+    FFPROBE = f"ffprobe{EXT}"
 
 @dataclass
 class AppConfig:

--- a/gui/group_logic.py
+++ b/gui/group_logic.py
@@ -1,3 +1,5 @@
+"""Logic mixin for managing file groups within the GUI."""
+
 from pathlib import Path
 import copy
 from PySide6.QtWidgets import QMessageBox

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,3 +1,5 @@
+"""Top-level application window and logic bindings."""
+
 from PySide6.QtWidgets import (
     QMainWindow,
     QVBoxLayout,
@@ -5,7 +7,7 @@ from PySide6.QtWidgets import (
     QFileDialog,
     QStatusBar,
 )
-from PySide6.QtCore import QSettings, Qt
+from PySide6.QtCore import QSettings
 import os
 
 from gui.widgets.group_bar import GroupBar
@@ -21,6 +23,7 @@ from .shortcut_logic import ShortcutLogic
 
 
 class MainWindow(QMainWindow, SettingsLogic, GroupLogic, TableLogic, ActionsLogic, ShortcutLogic):
+    """Main application window bundling all interface components."""
     def __init__(self):
         super().__init__()
         self.setWindowTitle("MKV Cleaner")
@@ -77,4 +80,3 @@ class MainWindow(QMainWindow, SettingsLogic, GroupLogic, TableLogic, ActionsLogi
             self.last_dir = os.path.dirname(files[0])
             self.settings.setValue("last_dir", self.last_dir)
             self.add_files_to_groups(files)
-


### PR DESCRIPTION
## Summary
- add module docstrings to configuration and GUI modules
- rename `ext` to `EXT` for executable suffix
- document `MainWindow` class
- clean imports and trailing newline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d5e7b55c8323869e33bffdd7b9c7