### PR TITLE
Add PyInstaller build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ The prebuilt bundles published in the GitHub releases already include PySide6
 and FFmpeg so no additional installation is required. Copies of their licenses
 are distributed alongside the bundle.
 
+## Building a standalone Windows executable
+
+If you want to create your own `MKVCleaner.exe`, run the
+`build_exe.py` script. It uses PyInstaller to bundle the Python
+dependencies while leaving the backend tools (`mkvmerge`,
+`mkvextract`, `ffmpeg` and `ffprobe`) on the system `PATH`.
+
+```bash
+python build_exe.py
+```
+
+The resulting executable can be found in the `dist` directory.
+
 ## Installation
 
 Install MKV Cleaner with `pip` after cloning the repository:

--- a/build_exe.py
+++ b/build_exe.py
@@ -1,0 +1,35 @@
+"""Build a standalone MKV Cleaner executable using PyInstaller.
+
+This script bundles the application and all Python dependencies into a single
+``MKVCleaner.exe`` file. The backend tools (``mkvmerge``, ``mkvextract``,
+``ffmpeg`` and ``ffprobe``) are intentionally excluded from the bundle. They
+must be available on ``PATH`` when running the generated executable.
+
+Run this script with ``python build_exe.py``. The resulting executable will be
+placed in the ``dist`` directory.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from PyInstaller.__main__ import run
+
+HERE = Path(__file__).resolve().parent
+
+logo = HERE / "MKV-Cleaner_logo.png"
+fonts_dir = HERE / "fonts"
+
+sep = ';' if os.name == 'nt' else ':'
+
+opts = [
+    "--name=MKVCleaner",
+    "--onefile",
+    "--noconsole",
+    f"--add-data={logo}{sep}.",
+    f"--add-data={fonts_dir}{sep}fonts",
+    str(HERE / "mkv_cleaner.py"),
+]
+
+if __name__ == "__main__":
+    run(opts)

--- a/core/config.py
+++ b/core/config.py
@@ -19,10 +19,16 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for older versions
 if getattr(sys, 'frozen', False):  # Running from PyInstaller bundle
     bindir = Path(getattr(sys, '_MEIPASS', Path(sys.executable).parent))
     EXT = '.exe' if os.name == 'nt' else ''
-    MKVMERGE = str(bindir / f"mkvmerge{EXT}")
-    MKVEXTRACT = str(bindir / f"mkvextract{EXT}")
-    FFMPEG = str(bindir / f"ffmpeg{EXT}")
-    FFPROBE = str(bindir / f"ffprobe{EXT}")
+    mkvmerge_path = bindir / f"mkvmerge{EXT}"
+    mkvextract_path = bindir / f"mkvextract{EXT}"
+    ffmpeg_path = bindir / f"ffmpeg{EXT}"
+    ffprobe_path = bindir / f"ffprobe{EXT}"
+    MKVMERGE = str(mkvmerge_path) if mkvmerge_path.exists() else f"mkvmerge{EXT}"
+    MKVEXTRACT = (
+        str(mkvextract_path) if mkvextract_path.exists() else f"mkvextract{EXT}"
+    )
+    FFMPEG = str(ffmpeg_path) if ffmpeg_path.exists() else f"ffmpeg{EXT}"
+    FFPROBE = str(ffprobe_path) if ffprobe_path.exists() else f"ffprobe{EXT}"
 else:
     EXT = '.exe' if os.name == 'nt' else ''
     MKVMERGE = f"mkvmerge{EXT}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
     "tomli; python_version < \"3.11\"",
 ]
 
+[project.optional-dependencies]
+build = ["pyinstaller"]
+
 [project.scripts]
 mkv-cleaner = "mkv_cleaner:main"
 


### PR DESCRIPTION
## Summary
- add a PyInstaller `build_exe.py` helper
- allow config to fall back to system tools when bundled
- document how to build a standalone Windows executable
- add optional PyInstaller dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684740f16ec48323972c037682e630bb