### PR TITLE
Fix release workflow tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,10 @@ jobs:
           path: dist/MKVCleaner.exe
 
       - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           files: dist/MKVCleaner.exe
+          tag_name: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- release workflow triggered on tag pushes and manual dispatch
- create release step now runs only for tag events
- tag name passed to release action

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848740ecd6c8323b3b1eeffe4361fc7